### PR TITLE
Updated mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -158,7 +158,7 @@ nav:
       - Function notation: basics/function-notation.md
       - Functional SQL: basics/funsql.md
       - Iteration: basics/iteration.md
-      - Iinterprocess communication: basics/ipc.md
+      - Interprocess communication: basics/ipc.md
       - Joins: basics/joins.md
       - Listening port: basics/listening-port.md
       - Logic: basics/logic.md


### PR DESCRIPTION
Corrected spelling mistake for Reference sections, Iinterprocess Communication → Interprocess Communication