### PR TITLE
Add -105!x extend trap

### DIFF
--- a/docs/basics/internal.md
+++ b/docs/basics/internal.md
@@ -495,3 +495,39 @@ Where `handle` is an int, `isError` is a boolean, and `msg` is a string
 Since V3.6 2018.05.18. 
 
 <i class="far fa-hand-point-right"></i> Knowledge Base: [Deferred response](../kb/deferred-response.md)
+
+## `-105!x` (extend trap)
+
+Syntax: `-105!(f;x;g)`
+
+Where
+
+-   `f` is a function
+-   `x` is a list of arguments
+-   `g` is a binary function
+
+extends [Trap](apply.md#trap) (`.[f;x;g]`) to collect backtrace: `g` gets called with arguments:
+
+1.   the error string
+2.   the backtrace object
+
+You can format the backtrace object with `.Q.sbt`.
+
+```q
+q)f:{x+y}
+q)           / print the formatted backtrace and error string to stderr
+q)-105!(f;(2;`a);{2@"error: ",x,"\nbacktrace:\n",.Q.sbt y;-1})
+error: type
+backtrace:
+  [1]  f:{x+y}
+           ^
+  [0]  -105!(f;(2;`a);{2@"error: ",x,"\nbacktrace:\n",.Q.sbt y;-1})
+           ^
+-1
+q)
+```
+
+Since V3.5 2017.03.15.
+
+<i class="far fa-hand-point-right"></i>
+[.Q.trp](../ref/dotq.md#qtrp-extend-trap)

--- a/docs/ref/apply.md
+++ b/docs/ref/apply.md
@@ -341,6 +341,9 @@ q).[+;2 3;{"Wrong ",x}]
 5
 ```
 
+<i class="far fa-hand-point-right"></i>
+[-105!](../basics/internal.md#-105x-extend-trap)
+
 
 ### Trap At
 
@@ -348,6 +351,8 @@ q).[+;2 3;{"Wrong ",x}]
 
 Use Trap At as a simpler form of Trap, for unary values.
 
+<i class="far fa-hand-point-right"></i>
+[.Q.trp](../ref/dotq.md#qtrp-extend-trap)
 
 ### Limit of the trap
 

--- a/docs/ref/dotq.md
+++ b/docs/ref/dotq.md
@@ -1356,7 +1356,7 @@ q)1@(h"f `a")1;    / output the backtrace string to stdout
 Since V3.5 2017.03.15.
 
 <i class="far fa-hand-point-right"></i> 
-Basics: [Debugging](../basics/debug.md)
+Basics: [Debugging](../basics/debug.md), [-105!](../basics/internal.md##-105!-extend-trap)
 
 
 ## `.Q.ts` (time and space)


### PR DESCRIPTION
`.Q.trp` is documented, which extends `@` trap for monadic functions. `-105!` (which extends `.` trap for higher valence functions) underlies this function, but is currently undocumented.

This PR adds description of `-105!x` (similar to description & example for `.Q.trp`) & some links between relevant parts of docs.