### PR TITLE
Fix dead links

### DIFF
--- a/docs/basics/datatypes.md
+++ b/docs/basics/datatypes.md
@@ -232,7 +232,7 @@ q)0w + 5
         q)-0Wh
         -32767h
 
-    Integer promotion is documented for [Add](../ref/add/#range-and-domains).
+    Integer promotion is documented for [Add](../../ref/add/#range-and-domains).
 
     Integer infinities 
 

--- a/docs/interfaces/q-server-for-odbc.md
+++ b/docs/interfaces/q-server-for-odbc.md
@@ -31,7 +31,7 @@ Ensure your q process has loaded the SQL interpreter.
 
 !!! warning "Windows 2003 hotfix KB948459"
 
-    If using Windows 2003, before installing ensure you have hotfix [KB948459](https://www.microsoft.com/en-gb/download/details.aspx?id=20065) applied. 
+    If using Windows 2003, before installing ensure you have hotfix KB948459 applied. 
 
 -   in W32, download :fontawesome-brands-github: [KxSystems/kdb/w32/odbc.zip](https://github.com/KxSystems/kdb/blob/master/w32/odbc.zip) and run it to install the q ODBC driver
 -   in W64, download :fontawesome-brands-github: [KxSystems/kdb/w64/odbc.zip](https://github.com/KxSystems/kdb/blob/master/w64/odbc.zip) and extract it to a temporary directory. Run `d0.exe` to install the q ODBC driver.

--- a/docs/ml/toolkit/utilities/util.md
+++ b/docs/ml/toolkit/utilities/util.md
@@ -26,7 +26,7 @@ keywords: pandas manipulation, dataframe, train test split, .
 </div>
 
 :fontawesome-brands-github:
-[KxSystems/ml/util/util.q](https://github.com/kxsystems/ml/blob/master/util/util.q)
+[KxSystems/ml/util/utilities.q](https://github.com/kxsystems/ml/blob/master/util/utilities.q)
 
 The toolkit contains utility functions, used in many applications and not limited to categories such as statistics or preprocessing.
 


### PR DESCRIPTION
1. `datatypes.md` - Needed an extra `..` to find relative path for `add.md`
2. `q-server-for-odbc.md` - Windows 2003 is out of support so this hotfix is no longer hosted by MS (The whole warning block could be chosen to be deleted?)
3. `util.md` - The file `util.q` has been renamed to `utilities.q`