### PR TITLE
Adding a back-to-top button

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,8 @@ site_name: 'Kdb+ and q documentation'
 site_url: https://code.kx.com/q/
 
 theme:
+  features:
+    - navigation.top
   custom_dir: custom_theme/
   favicon: https://code.kx.com/favicon.ico
   font: false


### PR DESCRIPTION
Minor edit: a back-to-top button for long articles such as white papers. See [official doc](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#back-to-top-button). This is useful especially when we need to scroll all the way to the top to reveal the tab items.