### PR TITLE
Details of trust store and additional examples

### DIFF
--- a/docs/interfaces/solace/examples.md
+++ b/docs/interfaces/solace/examples.md
@@ -30,15 +30,36 @@ Default values for all parameters are set in `sol_init.q`.
 -data   message payload to send
 -dest   name of endpoint queue to use or create
 -dtype  type of destination: [queue (default) | topic]
--host   broker hostname
+-host   SMF host URI (e.g. tcps://mymessage.solace.cloud:55443)
 -name   name of the endpoint to create
 -pass   password
 -queue  name of the exiting queue endpoint to alter
 -topic  topic name  (Solace wildcard format supported)
 -user   username
 -vpn    VPN name
+-trust  trust store i.e. directory containing Solace PEM file (when using secure SMF host connection)
+-opt    session capability
 ```
 
+## General Utilities
+
+### API version
+
+```syntax
+q sol_version.q
+```
+
+Prints the Solace API version currently in use
+
+### Query broker capabilities
+
+```syntax
+q sol_capabilities.q -opt SESSION_PEER_SOFTWARE_VERSION -host tcps://mr906gris.messaging.solace.cloud:55443 -user solace -pass ggut5 -vpn test -trust cert
+```
+
+Command-line arguments: `-host -vpn -trust -user -pass -name -opt`
+
+Requests capability value from the Solace broker. A list of capabilities are provided [here](https://docs.solace.com/API-Developer-Online-Ref-Documentation/c/sol_client_8h.html#sessioncapabilities)
 
 ## Endpoint interactions
 
@@ -48,7 +69,7 @@ Default values for all parameters are set in `sol_init.q`.
 q sol_endpoint_create.q <args>
 ```
 
-Command-line arguments: `-host -vpn -user -pass -name`
+Command-line arguments: `-host -vpn -trust -user -pass -name`
 
 Creates a queue on a Solace PubSub+ broker, subject to permission.
 
@@ -63,7 +84,7 @@ q sol_endpoint_create.q -name "Q/test"
 q sol_endpoint_destroy.q <args>
 ```
 
-Command-line arguments: `-host -vpn -user -pass -name`
+Command-line arguments: `-host -vpn -trust -user -pass -name`
 
 Removes an existing endpoint on the Solace broker, subject to permission.
 
@@ -78,7 +99,7 @@ q sol_endpoint_destroy.q -name "Q/test"
 q sol_topic_to_queue_mapping.q <args>
 ```
 
-Command-line arguments: `-host -vpn -user -pass -queue -topic`
+Command-line arguments: `-host -vpn -trust -user -pass -queue -topic`
 
 Adds a topic subscription to an existing endpoint queue, subject to permission.
 
@@ -96,7 +117,7 @@ q sol_topic_to_queue_mapping.q -queue "Q/test" -topic "Q/topic"
 q sol_pub_direct.q <args>
 ```
 
-Command-line arguments: `-host -vpn -user -pass -topic -data`
+Command-line arguments: `-host -vpn -trust -user -pass -topic -data`
 
 This can be used in conjunction with `sol_sub_direct.q` or any Solace example program.
 
@@ -111,10 +132,10 @@ q sol_pub_direct.q -topic "Q/1" -data "hello world"
 q sol_sub_direct.q <args>
 ```
 
-Command-line arguments: `-host -vpn -user -pass -topic`
+Command-line arguments: `-host -vpn -trust -user -pass -topic`
 
 ```bash
-q sol_sub_direct.q -host 192.168.65.2:55111 -topic "Q/>"
+q sol_sub_direct.q -host tcp://192.168.65.2:55111 -topic "Q/>"
 ```
 
 
@@ -124,7 +145,7 @@ q sol_sub_direct.q -host 192.168.65.2:55111 -topic "Q/>"
 q sol_pub_directrequestor.q <args>
 ```
 
-Command-line arguments: `-host -vpn -user -pass -topic -data`
+Command-line arguments: `-host -vpn -trust -user -pass -topic -data`
 
 Sends a direct message via a topic, and requests a reply as part of the published message.
 
@@ -140,12 +161,12 @@ q sol_pub_directrequestor.q -topic "Q/1" -data "hello world"
 q sol_sub_directrequestor.q <args>
 ```
 
-Command-line arguments: `-host -vpn -user -pass -topic`
+Command-line arguments: `-host -vpn -trust -user -pass -topic`
 
 Subscribes to a topic for the consumption of direct messages, replying to any message received.
 
 ```bash
-q sol_sub_directreplier.q -host 192.168.65.2:55111 -topic "Q/>"
+q sol_sub_directreplier.q -host tcp://192.168.65.2:55111 -topic "Q/>"
 ```
 
 
@@ -157,7 +178,7 @@ q sol_sub_directreplier.q -host 192.168.65.2:55111 -topic "Q/>"
 q sol_pub_persist.q <args>
 ```
 
-Command-line arguments: `-host -vpn -user -pass -data -dtype -dest -corr`
+Command-line arguments: `-host -vpn -trust -user -pass -data -dtype -dest -corr`
 
 Sends a persistent or guaranteed message to an existing endpoint.
 
@@ -173,7 +194,7 @@ q sol_pub_persist.q -dtype "queue" -dest "Q/1" -data "hello world" -corr 555
 q sol_sub_persist.q <args>
 ```
 
-Command-line arguments: `-host -vpn -user -pass -dest`
+Command-line arguments: `-host -vpn -trust -user -pass -dest`
 
 ```bash
 q sol_sub_persist.q -dest "Q/1"

--- a/docs/interfaces/solace/examples.md
+++ b/docs/interfaces/solace/examples.md
@@ -1,5 +1,5 @@
 ---
-title: Example usage | Solace | Interfaces | Docuemntation for q and kdb+
+title: Example usage | Solace | Interfaces | Documentation for q and kdb+
 author: Conor McCarthy
 description: Examples showing the use of the Solace kdb+ interface
 date: March 2020
@@ -41,7 +41,7 @@ Default values for all parameters are set in `sol_init.q`.
 -opt    session capability
 ```
 
-## General Utilities
+## General utilities
 
 ### API version
 
@@ -54,7 +54,9 @@ Prints the Solace API version currently in use
 ### Query broker capabilities
 
 ```syntax
-q sol_capabilities.q -opt SESSION_PEER_SOFTWARE_VERSION -host tcps://mr906gris.messaging.solace.cloud:55443 -user solace -pass ggut5 -vpn test -trust cert
+q sol_capabilities.q -opt SESSION_PEER_SOFTWARE_VERSION \
+    -host tcps://mr906gris.messaging.solace.cloud:55443 \
+    -user solace -pass ggut5 -vpn test -trust cert
 ```
 
 Command-line arguments: `-host -vpn -trust -user -pass -name -opt`

--- a/docs/interfaces/solace/reference.md
+++ b/docs/interfaces/solace/reference.md
@@ -238,7 +238,7 @@ _Connect to and create a session_
 
 Where `options` is a symbol-to-symbol dictionary mapping Solace [properties](https://docs.solace.com/API-Developer-Online-Ref-Documentation/c/group___session_props.html) to their values.
 
-Common properties are `SESSION_HOST`,  `SESSION_VPN_NAME`, `SESSION_USERNAME`, `SESSION_PASSWORD`, and `SESSION_RECONNECT_RETRIES`.
+Common properties are `SESSION_HOST`,  `SESSION_VPN_NAME`, `SESSION_USERNAME`, `SESSION_PASSWORD`, `SESSION_RECONNECT_RETRIES` and `SESSION_SSL_TRUST_STORE_DIR`.
 
 !!! tip "You must be connected before running any subsequent Solace functions."
 


### PR DESCRIPTION
Added some utility examples to solace interface.
Added details of trust store for secure connections to solace interface (solace changed the default connection type for Solace Cloud, so users may have had trouble connecting by following the old connections).