### PR TITLE
correct minor typo

### DIFF
--- a/docs/wp/query-routing/index.md
+++ b/docs/wp/query-routing/index.md
@@ -331,7 +331,7 @@ services:([handle:`int$()]
   address:`$();
   source:`$();
   gwHandle:`int$();
-  sq:`in t$();
+  sq:`int$();
   udt:`timestamp$() )
 
 serviceQueue:([gwHandle:`int$();sq:`int$()]


### PR DESCRIPTION
 sq:`i nt$(); 
corrected to 
sq:`int$();