### PR TITLE
Updated ca.pem hyperlink

### DIFF
--- a/docs/kb/ssl.md
+++ b/docs/kb/ssl.md
@@ -187,7 +187,7 @@ $ export SSL_VERIFY_SERVER=NO
 To allow verification of certificates which were not issued by you, you can import the CA bundle from reputable sources, e.g.
 
 ```bash
-$ curl https://curl.haxx.se/ca/cacert.pem > $HOME/certs/cabundle.pem
+$ curl https://curl.se/ca/cacert.pem > $HOME/certs/cabundle.pem
 $ export SSL_CA_CERT_FILE=$HOME/certs/cabundle.pem
 ```
 


### PR DESCRIPTION
`$ curl https://curl.haxx.se/ca/cacert.pem`
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="https://curl.se/ca/cacert.pem">here</a>.</p>
<hr>
<address>Apache Server at curl.haxx.se Port 80</address>
</body></html>