### PR TITLE
Update dotq.md

### DIFF
--- a/docs/ref/dotq.md
+++ b/docs/ref/dotq.md
@@ -1262,7 +1262,11 @@ When using `.Q.MAP[]` you can’t access the date column outside of the usual:
 select … [by date,…] from … where [date …]
 ```
  -->
-NOT recommended for use with compressed files, as the decompressed maps will be retained, using physical memory|swap.
+
+.Q.MAP currently has the following limitations:
+- .Q.MAP does not work with linked columns
+- .Q.MAP does not work with virtual partition columns
+- Use of .Q.MAP with compressed files is not recommended, as the uncompressed maps will be retained in memory
 
 ??? detail "You may need to increase the number of available file handles, and also the number of available file maps"
 


### PR DESCRIPTION
Amended to add lines as per email from Andrew Wilson.

.Q.MAP currently has the following limitations:
- .Q.MAP does not work with linked columns
- .Q.MAP does not work with virtual partition columns
- Use of .Q.MAP with compressed files is not recommended, as the uncompressed maps will be retained in memory