### PR TITLE
-p (or \p) can now listen on a port range

### DIFF
--- a/docs/basics/listening-port.md
+++ b/docs/basics/listening-port.md
@@ -22,6 +22,14 @@ Where
 kdb+ will listen to `portnumber` or the port number of `servicename` on all interfaces, or on `hostname` only if specified.
 The port must be available and the process must have permission for the port.
 
+As of 4.1t 2022.11.01 (or 4.0 2022.10.26) a port range can be specified in place of a portnumber. The range of ports is inclusive & tried in a random order. A service name can be used instead of each port number. Using 0W to choose a free ephemeral port can be more efficient (where suitable).
+
+```q
+q)\p 80/85
+q)\p
+81
+```
+
 Where no parameter is specified in the system command, the listening port is reported.
 The default is 0 (no listening port).
 

--- a/docs/basics/listening-port.md
+++ b/docs/basics/listening-port.md
@@ -22,7 +22,7 @@ Where
 kdb+ will listen to `portnumber` or the port number of `servicename` on all interfaces, or on `hostname` only if specified.
 The port must be available and the process must have permission for the port.
 
-As of 4.1t 2022.11.01 (or 4.0 2022.10.26) a port range can be specified in place of a portnumber. The range of ports is inclusive & tried in a random order. A service name can be used instead of each port number. Using 0W to choose a free ephemeral port can be more efficient (where suitable).
+As of 4.1t 2022.11.01 (or 4.0 2022.10.26) a port range can be specified in place of a portnumber. The range of ports is inclusive and tried in a random order. A service name can be used instead of each port number. Using 0W to choose a free ephemeral port can be more efficient (where suitable).
 
 ```q
 q)\p 80/85


### PR DESCRIPTION
-p cmd line option (or \p system command) can now listen on a port within a specified range e.g.
 q)\p 80/85
 q)\p
 81
range of ports is inclusive & tried in a random order. A service name can be used instead of a port number. The existing option of using 0W to choose a free ephemeral port can be more efficient (where suitable). range can be used in place of port number, when setting using existing rules e.g. for hostname
 q)\p myhost:2000/2010
or for multithreaded port
 q)\p -2000/2010