### PR TITLE
compression disabled for on all local interfaces

### DIFF
--- a/docs/basics/ipc.md
+++ b/docs/basics/ipc.md
@@ -236,7 +236,9 @@ byte | effect
 For releases since 2012.05.29, kdb+ and the C-API will compress an outgoing message if
 
 -   Uncompressed serialized data has a length greater than 2000 bytes
--   Connection is not `localhost` nor 127.0.0.1 (nor since 4.1t 2021.06.04, a connection that resolves to being localhost)
+-   Connection is not `localhost`
+-   Connection is not 127.0.0.1
+-   Connection does not resolve to being localhost (since 4.1t 2021.06.04)
 -   Size of compressed data is less than &frac12; the size of uncompressed data
 
 The compression/decompression algorithms are proprietary and implemented as the `compress` and `uncompress` methods in `c.java`. The message validator does not validate the integrity of compressed messages.

--- a/docs/basics/ipc.md
+++ b/docs/basics/ipc.md
@@ -236,7 +236,7 @@ byte | effect
 For releases since 2012.05.29, kdb+ and the C-API will compress an outgoing message if
 
 -   Uncompressed serialized data has a length greater than 2000 bytes
--   Connection is not `localhost`
+-   Connection is not `localhost` nor 127.0.0.1 (nor since 4.1t 2021.06.04, a connection that resolves to being localhost)
 -   Size of compressed data is less than &frac12; the size of uncompressed data
 
 The compression/decompression algorithms are proprietary and implemented as the `compress` and `uncompress` methods in `c.java`. The message validator does not validate the integrity of compressed messages.


### PR DESCRIPTION
ipc compression is disabled for connections on all local interfaces, previously was only disabled for connections to 127.0.0.1 or 'localhost'