### PR TITLE
open on a fifo now applies access rules

### DIFF
--- a/docs/basics/cmdline.md
+++ b/docs/basics/cmdline.md
@@ -373,8 +373,8 @@ Timeout in seconds for client queries, i.e. maximum time a client call will exec
 
 -   system commands from a remote (signals `'access`), including exit via `"\\"` 
 -   access to files outside the current directory for any handle context ([`.z.w`](../ref/dotz.md#zw-handle)) other than 0
-
--   the [`exit`](../ref/exit.md) keyword (since V4.1.t 2021-07-12)
+-   hopen on a fifo (since 4.1t 2021.10.13, 4.0 2023.08.11)
+-   the [`exit`](../ref/exit.md) keyword (since 4.1t 2021.07.12)
 
 ??? danger "Only a simple protection against “wrong” queries"
 


### PR DESCRIPTION
when used with -u 1