### PR TITLE
hopen on a file now applies access rules when used

### DIFF
--- a/docs/basics/cmdline.md
+++ b/docs/basics/cmdline.md
@@ -61,7 +61,8 @@ q)
 ```
 
 Block write-access to a kdb+ database, for any handle context ([`.z.w`](../ref/dotz.md#zw-handle)) other than 0.
-Also blocks [`hdel`](../ref/hdel.md) keyword (since V4.1t 2021.10.13, V4.0 2023.08.11).
+Blocks [`hdel`](../ref/hdel.md) keyword (since V4.1t 2021.10.13, V4.0 2023.08.11). 
+Blocks hopen of a file (since 4.1t 2021.10.13, 4.0 2023.08.11)
 
 ```bash
 ~/q$ q -b
@@ -375,6 +376,7 @@ Timeout in seconds for client queries, i.e. maximum time a client call will exec
 -   system commands from a remote (signals `'access`), including exit via `"\\"` 
 -   access to files outside the current directory for any handle context ([`.z.w`](../ref/dotz.md#zw-handle)) other than 0
 -   hopen on a fifo (since 4.1t 2021.10.13, 4.0 2023.08.11)
+-   hopen of a file (since 4.1t 2021.10.13, 4.0 2023.08.11)
 -   the [`exit`](../ref/exit.md) keyword (since 4.1t 2021.07.12)
 -   the [`hdel`](../ref/hdel.md) keyword (since V4.1t 2021.10.13, V4.0 2023.08.11)
 

--- a/docs/ref/eval.md
+++ b/docs/ref/eval.md
@@ -60,9 +60,13 @@ q)h"a:4"
 Behaves as if command-line options [`-u 1`](../basics/cmdline.md#-u-usr-pwd) and [`-b`](../basics/cmdline.md#-b-blocked) were active; also blocks all system calls which change state.
 That is, all writes to file system are blocked; allows read access to files in working directory and below only; and prevents amendment of globals.
 (Since V4.0 2020.03.17.)
-The [`exit`](exit.md) keyword is also blocked. (Since V4.1t 2021-07-12.)
+The [`exit`](exit.md) keyword is also blocked (since V4.1t 2021-07-12). Blocks hopen of a file (since 4.1t 2021.10.13, 4.0 2023.08.11)
 
-
+```q
+q)h:hopen 4000 / to a server started with -u 1 -p 4000
+q)h"reval(hopen;enlist`:somefile)"
+'access: somefile
+```
 
 ----
 :fontawesome-solid-book-open:


### PR DESCRIPTION
in reval, -b (blocked) mode, or with -u 1/file