### PR TITLE
.Q.dpft .Q.dpfts f arg dependancy

### DIFF
--- a/docs/ref/dotq.md
+++ b/docs/ref/dotq.md
@@ -377,7 +377,7 @@ Where
 
 -   `d` is a directory handle
 -   `p` is a partition of a database
--   `f` a field of the table (required to be present in table since 4.1t 2021.09.03) named by
+-   `f` a field of the table (required to be present in table since 4.1t 2021.09.03) named by `t` below
 -   `t`, the name (as a symbol) of a simple table whose columns are vectors or compound lists
 -   `s` is the handle of a symtable
 

--- a/docs/ref/dotq.md
+++ b/docs/ref/dotq.md
@@ -377,7 +377,7 @@ Where
 
 -   `d` is a directory handle
 -   `p` is a partition of a database
--   `f` a field of the table named by
+-   `f` a field of the table (required to be present in table since 4.1t 2021.09.03) named by
 -   `t`, the name (as a symbol) of a simple table whose columns are vectors or compound lists
 -   `s` is the handle of a symtable
 


### PR DESCRIPTION
.Q.dpft .Q.dpfts now require the `p# column (f argument) to be present in the table.