### PR TITLE
1022 connection limit increase

### DIFF
--- a/docs/basics/errors.md
+++ b/docs/basics/errors.md
@@ -89,7 +89,7 @@ cond
 
 conn
 
-:   Too many connections (1022 max)
+:   Too many connections. Max connections was 1022 prior to 4.1t 2023.09.15, otherwise the limit imposed by the operating system (operating system configurable for system/protocol).
 
 Could not initialize ssl
 

--- a/docs/wp/ipc/index.md
+++ b/docs/wp/ipc/index.md
@@ -140,7 +140,8 @@ q)`::[(`::4567;100);"1+1"]
 
 It is possible for a kdb+ process to have too many open connections. 
 The max is defined by the system limit for protocol (operating system configurable). Prior to 4.1t 2023.09.15, the limit was hardcoded to 1022.
-After the limit is reached, you will see the error `'conn` on the server process. (All successfully opened connections remain open).
+After the limit is reached, you see the error `'conn` on the server process. (All successfully opened connections remain open.)
+
 
 ```q
 q)\p 5678

--- a/docs/wp/ipc/index.md
+++ b/docs/wp/ipc/index.md
@@ -138,7 +138,9 @@ q)`::[(`::4567;100);"1+1"]
 2
 ```
 
-It is possible for a kdb+ process to have too many open connections. The limit is 1022, after which you will see the error `'conn` on the server process. (All successfully opened connections remain open).
+It is possible for a kdb+ process to have too many open connections. 
+The max is defined by the system limit for protocol (operating system configurable). Prior to 4.1t 2023.09.15, the limit was hardcoded to 1022.
+After the limit is reached, you will see the error `'conn` on the server process. (All successfully opened connections remain open).
 
 ```q
 q)\p 5678


### PR DESCRIPTION
now supports >1022 ipc/websocket connections; it is limited only by system and protocol.