### PR TITLE
http permits post with empty body

### DIFF
--- a/docs/ref/dotz.md
+++ b/docs/ref/dotz.md
@@ -679,6 +679,8 @@ There is no default implementation, but an example would be that it calls [`valu
 
 See `.z.ph` for details of the argument.
 
+Allows empty requests since 4.1t 2021.03.30 (previously signalled `length` error).
+
 :fontawesome-solid-book:
 [`.h` namespace](doth.md)
 <br>


### PR DESCRIPTION
http server now defaults Content-Length to 0, thus allowing empty request, previously threw 'length