### PR TITLE
fixed broken links

### DIFF
--- a/docs/cloud/azure/architecture.md
+++ b/docs/cloud/azure/architecture.md
@@ -68,7 +68,7 @@ The kdb+ infrastructure is often used to store internally derived data. This can
 
 A feedhandler is a process that captures external data and translates it into kdb+ messages. Multiple feedhandlers can be used to gather data from several different sources and feed it to the kdb+ system for storage and analysis.
 
-There are a number of open-source (Apache 2 licensed) [Fusion interfaces](../../interfaces/fusion.md) between KX and other third-party technologies. Feedhandlers are typically written in Java, Python, C++ and q.
+There are a number of open-source (Apache 2 licensed) [Fusion interfaces](../../interfaces/index.md) between KX and other third-party technologies. Feedhandlers are typically written in Java, Python, C++ and q.
 
 ### Tickerplant
 

--- a/docs/ref/select.md
+++ b/docs/ref/select.md
@@ -42,7 +42,7 @@ _p~w~_    Where phrase
 
 The `select` query returns a table for both [call-by-name and call-by-value](../basics/qsql.md#from-phrase).
 
-Since 4.1t 2021.03.30, select from [partitioned tables](../kb/partition.md) maps relevant columns within each partition in parallel (when running with [secondary threads](../q/basics/syscmds.md#s-number-of-secondary-threads)).
+Since 4.1t 2021.03.30, select from [partitioned tables](../kb/partition.md) maps relevant columns within each partition in parallel (when running with [secondary threads](../basics/syscmds.md#s-number-of-secondary-threads)).
 
 
 ## Minimal form

--- a/docs/ref/update.md
+++ b/docs/ref/update.md
@@ -17,7 +17,7 @@ For the Update operator `!`, see
 :fontawesome-solid-book-open:
 [Functional SQL](../basics/funsql.md)
 
-Since 4.1t 2021.06.04 updates from splayed table and path@tablename now leverage [peach](each.md) to load columns (when running with [secondary threads](../q/basics/syscmds.md#s-number-of-secondary-threads)).
+Since 4.1t 2021.06.04 updates from splayed table and path@tablename now leverage [peach](each.md) to load columns (when running with [secondary threads](../basics/syscmds.md#s-number-of-secondary-threads)).
 ```q
 q)update x:0 from get`:mysplay
 ```


### PR DESCRIPTION
Reported this on building site

WARNING  -  Documentation file 'cloud/azure/architecture.md' contains a link to 'interfaces/fusion.md' which is not found in the documentation files. 
WARNING  -  Documentation file 'ref/select.md' contains a link to 'q/basics/syscmds.md' which is not found in the documentation files. 
WARNING  -  Documentation file 'ref/update.md' contains a link to 'q/basics/syscmds.md' which is not found in the documentation files.