### PR TITLE
changed tldr to overview. Fixes #198

### DIFF
--- a/docs/learn/tour/index.md
+++ b/docs/learn/tour/index.md
@@ -16,7 +16,7 @@ It takes the form of a one-page ‘ridge walk’ along the tops, with optional s
 Use it as a very fast start with kdb+, or for a quick overview of what it is like to work in q.
 
 :fontawesome-regular-hand-point-left:
-[`TL;DR`](tldr.md)
+[`Overview`](overview.md)
 
 !!! tip "Before you start"
 

--- a/docs/learn/tour/overview.md
+++ b/docs/learn/tour/overview.md
@@ -10,7 +10,7 @@ description: A mountain tour of kdb+ and the q programming language, with links 
 ![Mountain walk](img/GettyImages-914651812.jpg)
 
 
-## `TL;DR`
+## `Overview`
 
 -   Kdb+ is an in-memory, column-store database optimized for time series. It has a tiny footprint and is seriously quick.
 -   The q vector-programming language is built into kdb+. It supports SQL-style queries.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -182,7 +182,7 @@ nav:
     - Install: learn/install.md
     - Licenses: learn/licensing.md
     - Mountain tour:
-      - TLDR: learn/tour/tldr.md
+      - Overview: learn/tour/overview.md
       - Begin here: learn/tour/index.md
       - The q session: learn/tour/session.md
       # - Databases: learn/tour/databases.md


### PR DESCRIPTION
tldr appears to stand for 'too long didnt read'
prob a throw back to some old doc, as the page is quite short