### PR TITLE
removed empty page and link. fixes #197

### DIFF
--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -57,10 +57,6 @@ Reading room](reading/index.md "Example programs for study")
 KX Developer](/developer/ "Download and install the free IDE, KX Developer")
 {: .md-button}
 
-[<span style="font-size: 3em">:fontawesome-solid-graduation-cap:</span><br/>
-Advanced q](advanced.md "Advanced topics in q")
-{: .md-button}
-
 </div>
 
 Kdb+ is a database. You can use it through [interfaces](../interfaces/index.md) such as ODBC, or from [Python](https://github.com/KxSystems/pyq). But its power and performance are best accessed through its own language, q.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -262,7 +262,6 @@ nav:
       - Transaction-cost analysis (WP): wp/transaction-cost.md
       - Trend indicators (WP): wp/trend-indicators/index.md
     - Advanced q:
-      # - Overview: learn/advanced.md
       - Remarks on Style: https://github.com/qbists/style
       - Shifts & scans: learn/shifts-scans.md
       - Technical articles: learn/blogs.md


### PR DESCRIPTION
https://code.kx.com/q/learn/advanced/ presents an empty page looks like it was commented out from the nav previously, but a link still remained. appears to be broken into sections now, each having a seperate page