### PR TITLE
erroneous socket usage from multiple threads

### DIFF
--- a/docs/basics/peach.md
+++ b/docs/basics/peach.md
@@ -117,7 +117,7 @@ A vector with _n_ items peached with function `f` with _s_ secondary processes o
 
     A handle must not be used concurrently between threads as there is no locking around a socket descriptor, and the bytes being read/written from/to the socket will be garbage (due to message interleaving) and most likely result in a crash. 
 
-Since V3.0, a socket can be used from the main thread only, or if you use the one-shot sync request syntax as
+Since V3.0, a socket can be used from the main thread only, or if you use the [one-shot sync request](../ref/hopen.md#one-shot-request) syntax as
 
 ```q
 q)`:localhost:5000 "2+2"

--- a/docs/kb/multithreaded-input.md
+++ b/docs/kb/multithreaded-input.md
@@ -39,6 +39,6 @@ Some of the restrictions are:
 5.  cannot send async messages
 6.  views can be recalculated from the main thread only
 
-The use of sockets from within those threads is not allowed for anything other than the [one-shot sync request](../ref/hopen.md#one-shot-request) and http client request only (TLS/SSL support added in 4.1t 2023.11.10). These can be inefficient, as it opens, queries and closes each time. Erroneous socket usage is blocked and signals a `nosocket` error.
+The use of sockets from within those threads is allowed only for the [one-shot sync request](../ref/hopen.md#one-shot-request) and HTTP client request (TLS/SSL support added in 4.1t 2023.11.10). These can be inefficient, as it opens, queries and closes each time. Erroneous socket usage is blocked and signals a `nosocket` error.
 
 In multithreaded input mode, the seed for the random-number generator used for threads other than the main thread is based on the socket descriptor for that connection; these threads are transient – destroyed when the socket is closed, and no context is carried over for new threads/connections.

--- a/docs/kb/multithreaded-input.md
+++ b/docs/kb/multithreaded-input.md
@@ -39,6 +39,6 @@ Some of the restrictions are:
 5.  cannot send async messages
 6.  views can be recalculated from the main thread only
 
-The use of sockets from within those threads is not allowed for anything other than the [one-shot sync request](../ref/hopen.md), which is the only socket opening supported in multithreaded mode. (Inefficient, as it opens, queries and closes each time).
+The use of sockets from within those threads is not allowed for anything other than the [one-shot sync request](../ref/hopen.md#one-shot-request) and http client request only (TLS/SSL support added in 4.1t 2023.11.10). These can be inefficient, as it opens, queries and closes each time. Erroneous socket usage is blocked and signals a `nosocket` error.
 
 In multithreaded input mode, the seed for the random-number generator used for threads other than the main thread is based on the socket descriptor for that connection; these threads are transient – destroyed when the socket is closed, and no context is carried over for new threads/connections.

--- a/docs/ref/each.md
+++ b/docs/ref/each.md
@@ -85,7 +85,7 @@ load master decryption key (-36!)
 
 And any **system command** which might cause a change of global state.
 
-Generally, do not use a **socket** within `peach`, unless it is encapsulated via one-shot or HTTP client request.
+Generally, do not use a **socket** within `peach`, unless it is encapsulated via [one-shot sync request](../ref/hopen.md#one-shot-request) or HTTP client request (TLS/SSL support added in 4.1t 2023.11.10). Erroneous socket usage is blocked and signals a `nosocket` error.
 
 If you are careful to manage your **file handles/file access** so that there is no parallel use of the same handle (or file) across threads, then you can open and close files within `peach`.
 


### PR DESCRIPTION
Block erroneous socket usage from multiple threads.
 N.B. Multithreaded input queue mode and peach allow one-shot sync and http(s) client request only;
      these threads cannot hopen, hclose, nor use sockets from other threads - throws 'nosocket for these cases.