### PR TITLE
alter .z.pp .z.ph details

### DIFF
--- a/docs/ref/doth.md
+++ b/docs/ref/doth.md
@@ -607,7 +607,7 @@ A basic example of showing keep-alive in action for a simple response:
 q)f:{[x;y]"HTTP/1.1 200 OK\r\nConnection : ",.h.ka[x*1000i],"\r\nContent-Type: ",(.h.ty`txt),"\r\nContent-Length: ",(string count y),"\r\n\r\n",y}
 q).z.ph:{f[2i;"test response\n"]}
 ```
-Running a HTTP client such as curl from the same machine will show the connection being reused for two requests
+Running an HTTP client such as cURL, from the same machine, shows the connection being reused for two requests.
 ```shell
 curl -v -v http://localhost:1234 http://localhost:1234
 ```

--- a/docs/ref/doth.md
+++ b/docs/ref/doth.md
@@ -596,9 +596,21 @@ q)1_.h.jx[5;`a]
 ```
 
 Where `x` is an integer representing the idle timeout in units of milliseconds. A value of 0i disables keepalive (i.e. .h.ka then returns "close").
+
 Returns a string of value `close` or `keep-alive` which can be used for the `Connection` HTTP header field value in the HTTP response.
 
-Can be used during the processing of an HTTP request to enable persistent connections i.e. should be called within an HTTP callback such as [.z.ph]((dotz.md#zph-http-get), [.z.pp](dotz.md#zpp-http-post), etc.
+Can be used during the processing of an HTTP request to enable [persistent connections](https://en.wikipedia.org/wiki/HTTP_persistent_connection) i.e. should be called within an HTTP callback such as [.z.ph](dotz.md#zph-http-get), [.z.pp](dotz.md#zpp-http-post), etc.
+
+A basic example of showing keep-alive in action for a simple response:
+```q
+\p 1234
+q)f:{[x;y]"HTTP/1.1 200 OK\r\nConnection : ",.h.ka[x*1000i],"\r\nContent-Type: ",(.h.ty`txt),"\r\nContent-Length: ",(string count y),"\r\n\r\n",y}
+q).z.ph:{f[2i;"test response\n"]}
+```
+Running a HTTP client such as curl from the same machine will show the connection being reused for two requests
+```shell
+curl -v -v http://localhost:1234 http://localhost:1234
+```
 
 
 ## `.h.logo` (KX logo)

--- a/docs/ref/doth.md
+++ b/docs/ref/doth.md
@@ -589,7 +589,7 @@ q)1_.h.jx[5;`a]
 ```
 
 
-## `.h.ka` (http keepalive)
+## `.h.ka` (HTTP keepalive)
 
 ```syntax
 .h.ka x

--- a/docs/ref/dotz.md
+++ b/docs/ref/dotz.md
@@ -567,6 +567,8 @@ Where `f` is a unary function, it is evaluated when a synchronous HTTP request i
 - `requestText` is parsed in `.z.ph` – detecting special cases like requests for CSV, XLS output – and the result is returned to the calling task.
 - `requestHeaderAsDictionary` contains a dictionary of [HTTP header](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields) names and values as sent by the client. This can be used to return content optimized for particular browsers.
 
+The function should return a string representation of a HTTP response message e.g. [HTTP/1.1 response message format](https://en.wikipedia.org/wiki/HTTP#HTTP/1.1_response_messages).
+
 Since V3.6 and V3.5 2019.11.13 the default implementation will call [`.h.val`](doth.md#hval-value) instead of [`value`](value.md), allowing users to interpose their own valuation code. It is called with `requestText` as the argument.
 
 :fontawesome-solid-hand-point-right:
@@ -663,7 +665,7 @@ Where `f` is a unary function, `.z.pp` is evaluated when an HTTP POST request is
 
 There is no default implementation, but an example would be that it calls [`value`](value.md) on the first item of its argument and returns the result to the calling task.
 
-See [`.z.ph`](#zph-http-get) for details of the argument.
+See [`.z.ph`](#zph-http-get) for details of the argument and return value.
 
 Allows empty requests since 4.1t 2021.03.30 (previously signalled `length` error).
 

--- a/docs/ref/dotz.md
+++ b/docs/ref/dotz.md
@@ -569,7 +569,7 @@ Where `f` is a unary function, it is evaluated when a synchronous HTTP request i
 
 The function returns a string representation of an HTTP response message e.g. [HTTP/1.1 response message format](https://en.wikipedia.org/wiki/HTTP#HTTP/1.1_response_messages).
 
-Since V3.6 and V3.5 2019.11.13 the default implementation will call [`.h.val`](doth.md#hval-value) instead of [`value`](value.md), allowing users to interpose their own valuation code. It is called with `requestText` as the argument.
+Since V3.6 and V3.5 2019.11.13, the default implementation calls [`.h.val`](doth.md#hval-value) instead of [`value`](value.md), allowing users to interpose their own valuation code. It is called with `requestText` as the argument.
 
 :fontawesome-solid-hand-point-right:
 [`.z.pp` port post](#zpp-http-post)

--- a/docs/ref/dotz.md
+++ b/docs/ref/dotz.md
@@ -564,35 +564,10 @@ Where `f` is a unary function, it is evaluated when a synchronous HTTP request i
 
 `.z.ph` is passed a single argument, a 2-item list `(requestText;requestHeaderAsDictionary)`:
 
-- `requestText` is parsed in `.z.ph` – detecting special cases like requests for CSV, XLS output – and the result is returned to the calling task. Since V3.6 and V3.5 2019.11.13 [`.h.val`](doth.md#hval-value) is called instead of `value`, allowing users to interpose their own valuation code.
-- `requestHeaderAsDictionary` contains information such as the user agent and can be used to return content optimized for particular browsers.
+- `requestText` is parsed in `.z.ph` – detecting special cases like requests for CSV, XLS output – and the result is returned to the calling task.
+- `requestHeaderAsDictionary` contains a dictionary of [HTTP header](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields) names and values as sent by the client. This can be used to return content optimized for particular browsers.
 
-```q
-q)\c 43 75
-q).last.ph
-    | ::
-when| 2007.08.16T12:20:32.681
-u   | `
-w   | 5
-a   | 2130706433
-x   | k){$[~#x:uh x:$[@x;x;*x];fram[$.z.f;x]("?";"?",*x:$."\\v");"?"=*x;..
-y   | (,"?";`Accept-Language`Accept-Encoding`Cookie`Referer`User-Agent`A..
-r   | "<html><head><style>a{text-decoration:none}a:link{color:024C7E}a:v..
-q).last.ph.y
-,"?"
-`Accept-Language`Accept-Encoding`Cookie`Referer`User-Agent`Accept`Connec..
-q).last.ph.y 0
-,"?"
-q).last.ph.y 1
-Accept-Language| "en-us"
-Accept-Encoding| "gzip, deflate"
-Cookie         | "defaultsymbol=AAPL"
-Referer        | "http://localhost:5001/"
-User-Agent     | "Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-us) Appl..
-Accept         | "text/xml,application/xml,application/xhtml+xml,text/ht..
-Connection     | "keep-alive"
-Host           | "localhost:5001"
-```
+Since V3.6 and V3.5 2019.11.13 the default implementation will call [`.h.val`](doth.md#hval-value) instead of [`value`](value.md), allowing users to interpose their own valuation code. It is called with `requestText` as the argument.
 
 :fontawesome-solid-hand-point-right:
 [`.z.pp` port post](#zpp-http-post)
@@ -688,7 +663,7 @@ Where `f` is a unary function, `.z.pp` is evaluated when an HTTP POST request is
 
 There is no default implementation, but an example would be that it calls [`value`](value.md) on the first item of its argument and returns the result to the calling task.
 
-See `.z.ph` for details of the argument.
+See [`.z.ph`](#zph-http-get) for details of the argument.
 
 Allows empty requests since 4.1t 2021.03.30 (previously signalled `length` error).
 

--- a/docs/ref/dotz.md
+++ b/docs/ref/dotz.md
@@ -567,7 +567,7 @@ Where `f` is a unary function, it is evaluated when a synchronous HTTP request i
 - `requestText` is parsed in `.z.ph` – detecting special cases like requests for CSV, XLS output – and the result is returned to the calling task.
 - `requestHeaderAsDictionary` contains a dictionary of [HTTP header](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields) names and values as sent by the client. This can be used to return content optimized for particular browsers.
 
-The function should return a string representation of a HTTP response message e.g. [HTTP/1.1 response message format](https://en.wikipedia.org/wiki/HTTP#HTTP/1.1_response_messages).
+The function returns a string representation of an HTTP response message e.g. [HTTP/1.1 response message format](https://en.wikipedia.org/wiki/HTTP#HTTP/1.1_response_messages).
 
 Since V3.6 and V3.5 2019.11.13 the default implementation will call [`.h.val`](doth.md#hval-value) instead of [`value`](value.md), allowing users to interpose their own valuation code. It is called with `requestText` as the argument.
 


### PR DESCRIPTION
Added links for clarity. Example was using scripts from a kb article so required you to have found/read that article previously.