### PR TITLE
Remove "curry" from compose title

### DIFF
--- a/docs/ref/compose.md
+++ b/docs/ref/compose.md
@@ -1,5 +1,5 @@
 ---
-title: Compose – compose/curry functions together | Reference | kdb+ and q documentation
+title: Compose – compose functions together | Reference | kdb+ and q documentation
 description: Compose is a q operator that composes (or curries) a unary value with another. The rank of the result is the rank of the second argument.
 author: Stephen Taylor
 keywords: adverb, compose, composition, function, kdb+, map, q, value


### PR DESCRIPTION
The term curry isn't very applicable in this context and is not used anywhere else in the text.

Discussion was here on slack here: https://kxsys.slack.com/archives/C3CNMRLKC/p1707427725422179