### PR TITLE
Fix  .Q.sha1 example

### DIFF
--- a/docs/ref/dotq.md
+++ b/docs/ref/dotq.md
@@ -1709,7 +1709,7 @@ Since V3.5 2017.03.15.
 Where `x` is a string, returns as a bytestream its SHA-1 hash.
 
 ```q
-q).Q.fc"Hello World!"
+q).Q.sha1"Hello World!"
 0x2ef7bde608ce5404e97d5f042f95f89f1c232871
 ```
 


### PR DESCRIPTION
The `.Q.sha1` example was using `.Q.fc` 