### PR TITLE
misleading info on how to run example

### DIFF
--- a/docs/learn/brief-introduction.md
+++ b/docs/learn/brief-introduction.md
@@ -443,7 +443,7 @@ The linked scripts allow you to build an on-disk database and run some queries a
 
 ### Building the database
 
-The database is built by running the `buildsmartmeterdb.q` script. You can vary the number of days of data to build, and the number of customer records per day. When you run the script, some information will be printed.
+The database is built by running the `buildsmartmeterdb.q` script. You can vary the number of days of data to build, and the number of customer records per day. When you run the script, some information is printed.
 
 ```bash
 $ q buildsmartmeterdb.q 

--- a/docs/learn/brief-introduction.md
+++ b/docs/learn/brief-introduction.md
@@ -443,13 +443,7 @@ The linked scripts allow you to build an on-disk database and run some queries a
 
 ### Building the database
 
-The database is built by running the `buildsmartmeterdb.q` script. You can vary the number of days of data to build, and the number of customer records per day. When you run the script, some information will be printed. Type
-
-```q
-go[]
-```
-
-to proceed.
+The database is built by running the `buildsmartmeterdb.q` script. You can vary the number of days of data to build, and the number of customer records per day. When you run the script, some information will be printed.
 
 ```bash
 $ q buildsmartmeterdb.q 


### PR DESCRIPTION
currenlty saying how to run the script before loading it, then repeating the info after loading the script.