### PR TITLE
Update blogs.md

### DIFF
--- a/docs/learn/blogs.md
+++ b/docs/learn/blogs.md
@@ -24,9 +24,7 @@ _A selection of technical articles of interest to kdb+ developers_
 -   [Parsing data in kdb+](https://kx.com/blog/kx-product-insights-parsing-data-in-kdb/), by Rian O’Cuinneagain
 -   [Server-as-a-Function: Providing RESTful JSON APIs in q](https://kx.com/blog/server-as-a-function-providing-restful-json-apis-in-q/), by Rob Moore
 -   [Deferred response](https://kx.com/blog/kdb-q-insights-deferred-response/), by Gopala Bhat
--   [qSQL vs standard SQL queries](https://kx.com/blog/kdb-qsql-versus-standard-sql-queries/), by Ryan Hamilton
 -   [Scripting with q](https://kx.com/blog/kdb-q-insights-scripting-with-q/), by David Crossey
--   [Thoughts on tables in kdb+](https://kx.com/blog/tech-talk-thoughts-tables-kdb/), by Paul Kerrigan
 
 
 ## Machine learning
@@ -35,7 +33,6 @@ _A selection of technical articles of interest to kdb+ developers_
 -   [Natural Language Processing](https://kx.com/blog/natural-language-processing-in-kx/)
 -   [A comparison of Python and q for handling lists](https://kx.com/blog/a-comparison-of-python-and-q-for-handling-lists/)
 -   [Feature extraction and selection in kdb+](https://kx.com/blog/machine-learning-toolkit-release-feature-extraction-and-selection-in-kdb/)
--   [Using q in Machine Learning with neural-network and clustering examples](https://kx.com/blog/using-q-machine-learning-neural-network-clustering-examples/)
 -   [Neural networks in kdb+](https://kx.com/blog/neural-networks-in-kdb-2/)
 -   [Using embedPy to apply LASSO regression](https://kx.com/blog/machine-learning-using-embedpy-to-apply-lasso-regression/)
 -   [Machine-Learning techniques featured in JupyterQ notebooks](https://kx.com/blog/machine-learning-techniques-featured-in-jupyterq-notebooks/)
@@ -46,27 +43,21 @@ _A selection of technical articles of interest to kdb+ developers_
 
 -   [Transitive comparisons](https://kx.com/blog/kdb-transitive-comparisons/)
 -   [Why the recent kdb+ wins matter](https://kx.com/blog/2018-benchmark-wrap-up-why-the-recent-kdb-wins-matter/)
--   [Benchmarking kdb+ on Raspberry Pi](https://kx.com/blog/benchmarking-kdb-raspberry-pi/)
 
 
 ## Applications and case studies
 
 -   [Data visualization with kdb+ using ODBC: A Tableau case study](https://kx.com/blog/data-visualization-with-kdb-using-odbc-a-tableau-case-study/)
--   [KX 1.1 billion taxi ride benchmark highlights advantages of kdb+ architecture](https://kx.com/blog/kx-1-1-billion-taxi-ride-benchmark-highlights-advantages-kdb-architecture/)
--   [kdb+ integral to BitMEX Bitcoin derivatives exchange growth strategy](https://kx.com/blog/use-case-kdb-integral-bitmex-bitcoin-derivatives-exchange-growth-strategy/)
 -   [Combining high-frequency cryptocurrency venue data using kdb+](https://kx.com/blog/combining-high-frequency-cryptocurrency-venue-data-using-kdb/)
 -   [Template of Fortnite gamer visualizations using Dashboards](https://kx.com/blog/kx-product-insights-template-of-fortnite-visualizations-in-destruction-using-dashboards/)
 -   [KX for Love!!](https://kx.com/blog/kx-for-love/)
 -   [Storing and exploring the Bitcoin blockchain](https://kx.com/blog/kdb-storing-and-exploring-the-bitcoin-blockchain/)
 -   [eFX: Data and analytics are the next arms race](https://kx.com/blog/current-trends-in-efx-data-and-analytics-are-the-next-arms-race/)
--   [KX for IoT: Industry 4.0 manufacturing](https://kx.com/blog/kx-iot-industry-4-0-manufacturing/)
 -   [IIoT for predictive maintenance and Big Data](https://kx.com/blog/kx-insights-iiot-predictive-maintenance-big-data/)
 -   [Quantile Technologies](https://kx.com/blog/powered-by-kx-quantile-technologies-limited/)
 -   [MIT Motorsports’ kdb+ Vehicle Telemetry System](https://kx.com/blog/kx-use-case-mit-motorsports-kdb-vehicle-telemetry-system/)
 -   [Consolidated audit trail go-live is now a certainty](https://kx.com/blog/kx-insights-consolidated-audit-trail-cat-go-live-now-appears-a-certainty/)
 -   [Signal processing with kdb+](https://kx.com/blog/signal-processing-with-kdb/)
--   [KX fueling IoT revolution with manufacturing win](https://kx.com/blog/kx-fueling-iot-revolution-manufacturing-win/)
--   [Overview of kdb+tick](https://kx.com/blog/overview-kdb-tick/)
 -   [Web scraping](https://kx.com/blog/web-scraping-a-kdb-use-case/)
 -   [The exploration of space weather at NASA FDL](https://kx.com/blog/nasa-frontier-development-lab-space-weather-challenge/)
 -   [Edge computing on a low-profile device](https://kx.com/blog/kx-poc-blog-series-edge-computing-on-a-low-profile-device/)
@@ -74,11 +65,6 @@ _A selection of technical articles of interest to kdb+ developers_
 
 ## Interfaces, tools, and platforms
 
--   [Kafka](https://kx.com/blog/kdb-interface-kafka/)
 -   [kdb+ on Anaconda and Google Cloud](https://kx.com/blog/kdb-on-anaconda-and-google-cloud/)
 -   [Migrating a kdb+ historical database to the Amazon Cloud](https://kx.com/blog/migrating-a-kdb-historical-database-to-the-amazon-cloud/)
--   [Interface to R](https://kx.com/blog/kdb-interface-r/)
--   [KX Analyst IDE](https://kx.com/blog/kx-product-insights-analyst-for-kx-ide/)
 -   [Momentum Ignition Alert](https://kx.com/blog/kx-product-insights-momentum-ignition-alert/)
-
-


### PR DESCRIPTION
This page links to blogs on the main KX.com site. Some of the old and out of date blog posts are no longer available on KX.com. Links to these have been removed from blogs.md.