### PR TITLE
removed duplicate info on mtim

### DIFF
--- a/docs/basics/listening-port.md
+++ b/docs/basics/listening-port.md
@@ -86,8 +86,26 @@ q)\p myhost:2000/2010     / use a free port between 2000 and 2010, using given h
 
 ## Multi-threaded port
 
-A negative port sets a [multi-threaded](../kb/multithreaded-input.md) port and if used it must be the initial and only mode of operation, i.e. do not dynamically switch between positive port and negative port.
+A negative port sets a [multi-threaded](../kb/multithreaded-input.md) port and if used it must be the initial and only mode of operation, 
+i.e. do not dynamically switch between positive port and negative port.
 
+Note that there are a number of restrictions in multithreaded mode:
+
+* queries are unable to update globals
+* [.z.po](../ref/dotz.md#zpo-open) is not called on connect
+* [.z.pc](../ref/dotz.md#zpc-close) is not called on disconnect
+* [.z.W](../ref/dotz.md#zw-handles) has a view on main thread sockets only
+* Cannot send async message
+* Views can be recalculated from the main thread only
+
+Multithreaded input mode supports WebSockets and HTTP (but not TLS) since 4.1t 2021.03.30. 
+TLS support available since 4.1t 2023.12.14. A custom [.z.ph](../ref/dotz.md#zph-http-get) which does not update global state should be used with HTTP.
+
+The use of sockets from within those threads is allowed only for the one-shot sync request and HTTP client request (TLS/SSL support added in 4.1t 2023.11.10). 
+These can be inefficient, as it opens, queries and closes each time. Erroneous socket usage is blocked and signals a nosocket error.
+
+In multithreaded input mode, the seed for the random-number generator used for threads other than the main thread is based on the socket descriptor for that connection; 
+these threads are transient – destroyed when the socket is closed, and no context is carried over for new threads/connections.
 
 ## Unix domain socket
 

--- a/docs/kb/multithreaded-input.md
+++ b/docs/kb/multithreaded-input.md
@@ -5,9 +5,6 @@ keywords: input, kdb+, mode, multithreaded, q, queue
 ---
 # Multithreaded input queue mode
 
-
-
-
 By default, kdb+ is single-threaded, and processes incoming queries sequentially.
 
 An additional mode exists, designed for serving in-memory static data to an externally constrained number of clients only; it is not intended for use as a gateway, or serving mutable data, or data from disk. Each incoming connection is executed in its own thread, and is unable to update globals – it is purely functional in the sense that the execution of a query should not have side-effects.
@@ -18,27 +15,8 @@ Updates to globals are allowed only if they occur from within [`.z.ts`](../ref/d
 
 The switching in and out of this mode now checks to avoid the situation where the main thread could have a socket open, and sockets being processed in other threads simultaneously.
 
-Multithreaded input queue mode is active when the port for incoming connections is specified as negative, e.g. for startup
+Multithreaded input queue mode is active when the port for incoming connections is specified as [negative](../basics/listening-port.md#negative-ports), e.g. for startup
 
 ```bash
 $ q -p -5000
 ```
-
-Multithreaded input mode supports WebSockets and HTTP (but not TLS) since 4.1t 2021.03.30. TLS support available since 4.1t 2023.12.14.
-A custom [`.z.ph`](../ref/dotz.md#zph-http-get) which does not update global state should be used with HTTP. 
-
-
-## Restrictions
-
-Some of the restrictions are:
-
-1.  queries are unable to update globals
-2.  [`.z.po`](../ref/dotz.md#zpo-open) is not called on connect
-3.  [`.z.pc`](../ref/dotz.md#zpc-close) is not called on disconnect
-4.  [`.z.W`](../ref/dotz.md#zw-handles) has a view on main thread sockets only
-5.  cannot send async messages
-6.  views can be recalculated from the main thread only
-
-The use of sockets from within those threads is allowed only for the [one-shot sync request](../ref/hopen.md#one-shot-request) and HTTP client request (TLS/SSL support added in 4.1t 2023.11.10). These can be inefficient, as it opens, queries and closes each time. Erroneous socket usage is blocked and signals a `nosocket` error.
-
-In multithreaded input mode, the seed for the random-number generator used for threads other than the main thread is based on the socket descriptor for that connection; these threads are transient – destroyed when the socket is closed, and no context is carried over for new threads/connections.

--- a/docs/wp/ipc/index.md
+++ b/docs/wp/ipc/index.md
@@ -222,7 +222,7 @@ The TLS protocol is used to communicate across a network in a way designed to pr
 
 ### Negative ports
 
-A kdb+ process can be started in multithreaded input mode by setting a negative port number. A multithreaded process will use separate threads for every process that connects, which means that each client request can be executed on a separate CPU.
+A kdb+ process can be started in multithreaded input mode by setting a [negative port number](../../basics/listening-port.md#multi-threaded-port). A multithreaded process will use separate threads for every process that connects, which means that each client request can be executed on a separate CPU.
 
 Although secondary processes are used to farm queries out to multiple processes, they still have a single-threaded input queue. By using a negative port number, it is possible to multithread that queue too.
 
@@ -237,15 +237,6 @@ q)\p
 
 Connections can be opened to this process in the same way as described previously for positive port numbers.
 
-Note that there are a number of restrictions in multithreaded mode:
-
--   Queries cannot update globals
--   `.z.pc` is not called on disconnect
--   `.z.W` has a view of main thread sockets only
--   Cannot send async messages
--   Cannot serve HTTP requests
--   Views can be recalculated from the main thread only
-
 ```q
 q)h:hopen 4567
 q)h"1+1"
@@ -255,7 +246,6 @@ q)h"a:2"
   [0]  h"a:2"
        ^
 ```
-
 
 :fontawesome-solid-graduation-cap:
 [Multithreaded input](../../kb/multithreaded-input.md)


### PR DESCRIPTION
moved info into main reference material. info was repeated in 2 different places. linked to main ref material