### PR TITLE
removed white paper naming

### DIFF
--- a/docs/cloud/autoscale/index.md
+++ b/docs/cloud/autoscale/index.md
@@ -4,9 +4,6 @@ description: How to auto-scale a cloud deployment of kdb+ realtime database
 author: Jack Stapleton
 date: September 2020
 ---
-White paper
-{: #wp-brand}
-
 # Auto Scaling for a kdb+ realtime database
 
 

--- a/docs/cloud/aws-lambda/index.md
+++ b/docs/cloud/aws-lambda/index.md
@@ -1,5 +1,5 @@
 ---
-title: Serverless q/kdb+ on AWS Lambda | White Papers | kdb+ and q documentation
+title: Serverless q/kdb+ on AWS Lambda | kdb+ and q documentation
 description: How to deploy kdb+ processes on AWS Lambda, an event-driven, serverless computing platform using the Serverless Application Repository and Cloud Development Kit
 author: Eric Corcoran
 date: March 2020

--- a/docs/interfaces/csharp.md
+++ b/docs/interfaces/csharp.md
@@ -11,4 +11,4 @@ A kdb+ interface for the C# programming language is documented and available for
 The interface permits connecting C# and kdb+ processes via IPC.
 
 :fontawesome-regular-map:
-[White paper: An introduction to graphical interfaces for kdb+ using C#](../wp/gui/index.md)
+[An introduction to graphical interfaces for kdb+ using C#](../wp/gui/index.md)

--- a/docs/interfaces/index.md
+++ b/docs/interfaces/index.md
@@ -24,10 +24,10 @@ Our Fusion interfaces are
 <tr markdown><td markdown>[jdbc](https://github.com/KxSystems/jdbc)</td><td markdown>**JDBC** driver for kdb+</td>
 <tr markdown><td markdown>[kafka](https://github.com/KxSystems/kafka)</td><td markdown>Q client for **Apache Kafka**</td></tr>
 <tr markdown><td markdown>[ldap](https://github.com/KxSystems/ldap)</td><td markdown>Q client for **LDAP**</td></tr>
-<tr markdown><td markdown>[mqtt](https://github.com/KxSystems/mqtt)</td><td markdown>Q client for **MQTT** [:fontawesome-regular-map:](../wp/iot-mqtt/index.md "White paper: Internet of Things with MQTT")</td></tr>
+<tr markdown><td markdown>[mqtt](https://github.com/KxSystems/mqtt)</td><td markdown>Q client for **MQTT** [:fontawesome-regular-map:](../wp/iot-mqtt/index.md "Internet of Things with MQTT")</td></tr>
 <tr markdown><td markdown>[prometheus-kdb-exporter](https://github.com/KxSystems/prometheus-kdb-exporter)</td><td markdown>Export kdb+ metrics to **Prometheus**</td></tr>
 <tr markdown><td markdown>[protobufkdb](https://github.com/KxSystems/protobufkdb)</td><td markdown>Read and write **Protocol Buffers** data</td></tr>
-<tr markdown><td markdown>[solace](https://github.com/KxSystems/solace)</td><td markdown>Query kdb+ from a **Solace** event broker [:fontawesome-regular-map:](../wp/solace/index.md "White paper: Publish/subscribe with the Solace event broker")</td></tr>
+<tr markdown><td markdown>[solace](https://github.com/KxSystems/solace)</td><td markdown>Query kdb+ from a **Solace** event broker [:fontawesome-regular-map:](../wp/solace/index.md "Publish/subscribe with the Solace event broker")</td></tr>
 </tr>
 </table>
 

--- a/docs/ref/iterators.md
+++ b/docs/ref/iterators.md
@@ -24,7 +24,7 @@ They are the primary means of iterating in q.
 [Iteration](../basics/iteration.md) in q
 <br>
 :fontawesome-regular-map:
-White paper: [Iterators](../wp/iterators/index.md)
+[Iterators](../wp/iterators/index.md)
 
 !!! detail "Applicable value"
 

--- a/docs/wp/astronomy.md
+++ b/docs/wp/astronomy.md
@@ -1,20 +1,13 @@
 ---
-title: kdb+ in astronomy | White papers | kdb+ and q documentation
+title: kdb+ in astronomy | kdb+ and q documentation
 description: Imports FITS data to kdb+, loads C functions and calculates recessional velocity
 author: [Andrew Magowan, James Neill]
 keywords: api, astronomy, dynamic load, fits, galaxy, kdb+, q, quasi-stellar objects, recessional velocity, red shift, telescope
 ---
-White paper
-{: #wp-brand}
-
 # kdb+ in astronomy
 
 by [Andrew Magowan &amp; James Neill](#authors)
 {: .wp-author}
-
-
-
-
 
 
 The field of observational astronomy has always been data-driven, but like many other fields, technological advances are causing something of a paradigm shift, and – according to experts – a bit of a headache! Currently under construction are new infrastructures that have the potential to record volumes of data that have not been seen before in the field. The Large Synoptic Survey Telescope (LSST) and Square Kilometer Array (SKA) are set to record such huge amounts of data that experts are concerned about their ability to make sense of this data, purely due to its sheer size.

--- a/docs/wp/astronomy.md
+++ b/docs/wp/astronomy.md
@@ -41,7 +41,7 @@ KX provides a header file, `k.h`, for interacting with C from kdb+. It provides 
 
 :fontawesome-regular-hand-point-right:
 Interfaces: [C client for kdb+](../interfaces/c-client-for-q.md)<br>
-White paper: [“C API for kdb+”](capi/index.md)<br>
+[“C API for kdb+”](capi/index.md)<br>
 :fontawesome-brands-github:
 [KxSystems/kdb](https://github.com/kxsystems/kdb)<br>
 James Neill’s repository for kdb+ in astronomy:
@@ -245,12 +245,12 @@ We can infer from these results that quasi-stellar objects (QSOs) have the great
 
 As previously mentioned, the positive impact of having the SDSS data available to the public has been massive. Since it was released, over 3,000 papers have been written on a range of different topics in the field, based on [data from the SDSS](http://onlinelibrary.wiley.com/doi/10.1111/j.1740-9713.2012.00587.x/pdf). 
 
-The SDSS is just one example of several projects, but it shows the benefit of making the data accessible to all interested parties, both professional and amateur. This impact throughout the wider astronomical community has pushed leaders in the field to continue this development – to further promote sky surveys by building bigger, more powerful telescopes. However, this doesn’t come without its problems, with data storage and computational processing power being pushed to the limits. kdb+ has the ability to scale to these extremes. Sean Keevey’s white paper [“A natural query interface for distributed systems”](query-interface.md) discusses how data distributed over several processes and machines can be seamlessly accessed from a single
+The SDSS is just one example of several projects, but it shows the benefit of making the data accessible to all interested parties, both professional and amateur. This impact throughout the wider astronomical community has pushed leaders in the field to continue this development – to further promote sky surveys by building bigger, more powerful telescopes. However, this doesn’t come without its problems, with data storage and computational processing power being pushed to the limits. kdb+ has the ability to scale to these extremes. Sean Keevey’s [“A natural query interface for distributed systems”](query-interface.md) discusses how data distributed over several processes and machines can be seamlessly accessed from a single
 starting point by the end user. 
 
 We previously mentioned how astronomy data can often come with a time domain, which would be well suited to kdb+ and how the data would be stored on disk. The data set in this example does not have a time domain, as it just provides information on given objects recorded once, but this certainly does not mean that it is not suited to kdb+. 
 
-We could apply an attribute to this data for optimization, such as the sorted attribute to the class column in the example data set. The benefits of this would become more apparent as more files were being loaded in. Ciaran Gorman’s white paper [“Columnar database and query optimization”](columnar-database/index.md) gives an in-depth explanation as to how they can be applied. 
+We could apply an attribute to this data for optimization, such as the sorted attribute to the class column in the example data set. The benefits of this would become more apparent as more files were being loaded in. Ciaran Gorman’s [“Columnar database and query optimization”](columnar-database/index.md) gives an in-depth explanation as to how they can be applied. 
 
 
 ## Conclusion

--- a/docs/wp/blockchain/index.md
+++ b/docs/wp/blockchain/index.md
@@ -479,7 +479,7 @@ common column to group data together. Such [partitioned
 table](/q4m3/14_Introduction_to_Kdb+/#143-partitioned-tables)
 structures help to more easily manage large datasets and enable query
 optimization. For more information on the benefits of partitioned
-databases, see white paper “[Columnar database and query
+databases, see “[Columnar database and query
 optimization](../columnar-database/index.md)”.
 
 For `mainDB`, each table contains a common column named `height`
@@ -627,7 +627,7 @@ comparisons performed when searching for an address or TXID within a
 given partition.
 
 For more information on the performance enhancements achieved by on-disk
-attribute application, refer again to the white paper [Columnar database and query optimization](../columnar-database/index.md).
+attribute application, refer again to [Columnar database and query optimization](../columnar-database/index.md).
 
 
 ### Memory management 
@@ -687,7 +687,7 @@ heightToPartition:{[Height;Width]
 ```
 
 :fontawesome-regular-hand-point-right:
-White paper: [Intraday Writedown Solutions](../intraday-writedown/index.md)
+[Intraday Writedown Solutions](../intraday-writedown/index.md)
 
 
 #### Garbage collection
@@ -724,7 +724,7 @@ q).z.zd:17 2 6
 The above setting resulted in a compression ratio of 2.7 on average. 
 
 :fontawesome-regular-hand-point-right:
-White paper: [Compression in kdb+](../compress/index.md)
+[Compression in kdb+](../compress/index.md)
 
 
 #### Assigning appropriate data types

--- a/docs/wp/blockchain/index.md
+++ b/docs/wp/blockchain/index.md
@@ -1,18 +1,14 @@
 ---
-title: Storing and exploring the Bitcoin blockchain | White Papers | kdb+ and q documentation
+title: Storing and exploring the Bitcoin blockchain | kdb+ and q documentation
 description: A blockchain explorer uses kdb+ to store and query Bitcoin transactions using partitioned databases, splayed tables, intraday write-downs, and in-memory joins.
 author: [Jeremy Lucid, Daniel Irwin]
 date: December 2018
 keywords: bitcoin, blockchain, kdb+, q
 ---
-White paper
-{: #wp-brand}
-
 # Storing and exploring the Bitcoin blockchain
 
 by [Jeremy Lucid &amp; Daniel Irwin](#authors)
 {: .wp-author}
-
 
 
 For over a decade, KX technology has played an important role in the

--- a/docs/wp/capi/index.md
+++ b/docs/wp/capi/index.md
@@ -1,19 +1,15 @@
 ---
-title: C API for kdb+ | White Papers | kdb+ and q documentation
+title: C API for kdb+ | kdb+ and q documentation
 description: How to connect a C program to a kdb+ database
 author: Jeremy Lucid
 date: December 2018
 keywords: kdb+, q, real-time, streaming, subscribe, tick
 ---
-White paper
-{: #wp-brand}
-
 # C API for kdb+
 
 by [Jeremy Lucid](#author)
 {: .wp-author}
 
- 
 
 
 In its traditional financial domain, and across an increasingly broad range of industries, one of the main strengths of kdb+ is its flexibility in integrating and communicating with external systems. This adoption-enhancing feature is facilitated through a number of interfaces, including C and Java APIs, ODBC support, HTTP and WebSockets. 

--- a/docs/wp/capi/index.md
+++ b/docs/wp/capi/index.md
@@ -16,7 +16,7 @@ In its traditional financial domain, and across an increasingly broad range of i
 
 This paper will illustrate how the C API can be used to enable a C program to interact with a kdb+ process, and so leverage the real-time streaming and processing strengths of kdb+. Particular consideration will be given to how the API can facilitate subscription and publication to a kdb+ tickerplant process, a core component of any kdb+ tick-capture system. Just as trade and quote data can be piped into a financial kdb+ application through a C feedhandler, interesting new datasets in non-financial industries can readily be consumed and processed with minimal setup work in C.
 
-For example, in a recent white paper “[kdb+ in astronomy](../astronomy.md)” a standard scientific file format is loaded into kdb+ for fast calculation of the recessional velocities of celestial bodies.
+For example, in “[kdb+ in astronomy](../astronomy.md)” a standard scientific file format is loaded into kdb+ for fast calculation of the recessional velocities of celestial bodies.
 
 While [Interfaces: C](../../interfaces/c-client-for-q.md) remains the primary source for up-to-date information on the C API, the examples presented here provide a complementary set of practical templates. These templates can be combined and used to apply kdb+ across a broad range of problem domains. 
 
@@ -271,7 +271,7 @@ In general, there are two common types of errors; those generated during the soc
 As an example of an initialization error, the ”Authentication Error” will occur when the user name or password credentials passed to `khpu` are invalid. In kdb+, a process can be started in a restricted access mode where only users with valid credentials can connect.
 
 :fontawesome-regular-hand-point-right: 
-White paper: [WebSockets](../websockets/index.md)
+[WebSockets](../websockets/index.md)
 
 Similarly, the ”Connection error” can result for incorrect hostname or port numbers being passed to `khpu`.
 
@@ -357,9 +357,9 @@ handle value.
 k(-handle, "1.0 + 2.0", (K)0);
 ```
 
-The asynchronous option is recommended when maximum data throughput is desired and the sender does not require an acknowledgment. Greater technical details on synchronous vs asynchronous requests can be found in the following white papers.
+The asynchronous option is recommended when maximum data throughput is desired and the sender does not require an acknowledgment. Greater technical details on synchronous vs asynchronous requests can be found in the following:
 
-:fontawesome-regular-hand-point-right: White papers:  
+:fontawesome-regular-hand-point-right: 
 [Common design principles for kdb+ gateways](../gateway-design/index.md)  
 [Query Routing: A kdb+ framework for a scalable, load balanced system](../query-routing/index.md)
 
@@ -1315,7 +1315,7 @@ A kdb+ tickerplant is a kdb+ process specifically designed to handle incoming, h
 ![Architecture](img/architecture.png)
 
 :fontawesome-regular-hand-point-right:
-White paper: [Building real-time tick subscribers](../rt-tick/index.md)
+[Building real-time tick subscribers](../rt-tick/index.md)
 
 
 ### Test tickerplant and feedhandler setup
@@ -1624,7 +1624,7 @@ int main() {
 
 ### Publishing multiple rows using a mixed-list object
 
-For performance-related reasons, discussed in the white paper, [kdb+tick profiling for throughput optimization](../tick-profiling.md) it is recommended to publish multiple rows at once so that bulk inserts can be performed on the tickerplant, maximizing tickerplant eﬃciency.
+For performance-related reasons, discussed in [kdb+tick profiling for throughput optimization](../tick-profiling.md) it is recommended to publish multiple rows at once so that bulk inserts can be performed on the tickerplant, maximizing tickerplant eﬃciency.
 
 > Feeds should read as many messages off the socket as possible and send bulk updates to the tickerplant if possible. Bulk updates will greatly increase the maximum throughput achievable.
 

--- a/docs/wp/card-counters/index.md
+++ b/docs/wp/card-counters/index.md
@@ -1,19 +1,14 @@
 ---
-title: "Streaming analytics with kdb+: Detecting card counters in Blackjack | White Papers | q and kdb+ documentation"
+title: "Streaming analytics with kdb+: Detecting card counters in Blackjack | q and kdb+ documentation"
 author: [Caolan Rafferty, Krishan Subherwal]
 description: Using kdb+ event-stream processing analytics in real time to detect card counters in Blackjack
 date: May 2017
 keywords: analytics, blackjack, card counting, event-stream, kdb+, q
 ---
-White paper
-{: #wp-brand}
-
 # Streaming analytics with kdb+:<br>Detecting card counters in Blackjack
 
 by [Caolan Rafferty &amp; Krishan Subherwal](#authors)
 {: .wp-author}
-
-
 
 
 With the growth and acceleration of the Internet of Things, data collection is increasingly being performed by sensors and smart devices. Sensors are able to detect just about any physical element from a multitude of machines, including mobile phones, vehicles, appliances and meters. Airlines are currently using smart devices to prevent failures, producing as much as 40 terabytes of data per hour per flight. Consuming and analyzing the massive amounts of data transmitted from sensing devices is considered the next Big Data challenge for businesses.

--- a/docs/wp/columnar-database/index.md
+++ b/docs/wp/columnar-database/index.md
@@ -1,18 +1,14 @@
 ---
-title: Columnar database and query optimization | White Papers | documentation for q and kdb+
+title: Columnar database and query optimization | documentation for q and kdb+
 description: Methods available to developers for optimizing queries to a kdb+ database
 date: June 2012
 author: Ciáran Gorman
 keywords: attribute, columnar, database, grouped, kdb+, optimize, partitioned, performance, q, query, sorted, unique
 ---
-White paper
-{: #wp-brand}
-
 # Columnar database and query optimization
 
 by [Ciáran Gorman](#author)
 {: .wp-author}
-
 
 
 

--- a/docs/wp/compress/index.md
+++ b/docs/wp/compress/index.md
@@ -5,16 +5,10 @@ author: Eoin Killeen
 date: October 2013
 keywords: compress, compression ratio, datatype, get, gzip, kdb+, logical block size, performance, q, set, 
 ---
-White paper
-{: #wp-brand}
-
 # Compression in kdb+
 
 by [Eoin Killeen](#author)
 {: .wp-author}
-
-
-
 
 
 As the rate of data generation in financial markets continues to increase, there is a strong impetus to investigate how large data volumes can be more efficiently processed. Even if disk is considered cheap, it can be a valuable exercise for many applications to determine what improvements can be gleaned from an analysis of the use of compression. Aside from reduced disk costs, some use cases can gain significant performance improvements through a problem-specific approach to compression. For example, some systems have fast CPUs, but find that disk I/O is a bottleneck. In some such cases, utilizing CPU power to reduce the amount of data being sent to disk can improve

--- a/docs/wp/compress/index.md
+++ b/docs/wp/compress/index.md
@@ -1,5 +1,5 @@
 ---
-title: Compression in kdb+ | White papers | q and kdb+ documentation
+title: Compression in kdb+ | q and kdb+ documentation
 description: introduction to compression in kdb+, contributing factors to compression ratios and performance, and how the use of compressed data can affect performance 
 author: Eoin Killeen
 date: October 2013

--- a/docs/wp/corporate-actions.md
+++ b/docs/wp/corporate-actions.md
@@ -265,7 +265,7 @@ q)cact:`s#cact;
 Within the majority of kdb+ systems, data is obtained through the use of a gateway process.
 
 :fontawesome-regular-hand-point-right:
-White paper: [Common design principles for kdb+ gateways](gateway-design/index.md)
+[Common design principles for kdb+ gateways](gateway-design/index.md)
 
 The gateway acts as an interface between the end user and the underlying databases. We would like to pass many different parameters into the function `getRes` that executes the query on the database, and perhaps more than the maximum number allowed in q, which is eight. For this reason we will use a dictionary as the single parameter. A typical parameter dictionary looks like the following:
 

--- a/docs/wp/corporate-actions.md
+++ b/docs/wp/corporate-actions.md
@@ -1,19 +1,14 @@
 ---
-title: "Temporal data: a kdb+ framework for corporate actions | White Papers | documentation for q and kdb+"
+title: "Temporal data: a kdb+ framework for corporate actions | documentation for q and kdb+"
 author: Sean Rodgers
 date: March 2014
 description: Examines a kdb+ framework which can be used to apply corporate action adjustments on the fly to equity tick data
 keywords: adjustment, corporate action, cash dividend, dividend, framework, name change, reference data, spin off, stock split, temporal data
 ---
-White paper
-{: #wp-brand}
-
 # Temporal data:<br>A kdb+ framework for corporate actions
 
 by [Sean Rodgers](#author)
 {: .wp-author}
-
-
 
 
 kdb+ is leveraged in many financial institutions across the globe and has built a well-earned reputation as a high-performance database, appropriate for capturing, storing and analyzing enormous amounts of data. It is essential that any large-scale kdb+ system has an efficient design so that time to value is kept to a minimum and the end users are provided with useful functionality.

--- a/docs/wp/data-loaders/index.md
+++ b/docs/wp/data-loaders/index.md
@@ -98,7 +98,7 @@ Each worker will read, transform, map and upsert data to a relevant schema and t
 Once all files of a batch are loaded, the workers will be tasked with merging a list of specific columns, sorting based on the index from the files saved and if necessary include any existing data from the HDB during the sort and merge. Once the merge is complete the table will be moved to the HDB, during which all queries to the HDB will be temporarily disabled using a lockfile.
 
 :fontawesome-regular-map:
-White paper: [“Intraday writedown solutions”](../intraday-writedown/index.md)
+[“Intraday writedown solutions”](../intraday-writedown/index.md)
 for similar solutions
 
 Workers can be killed after each batch to free up memory rather than each worker running garbage collection, which can be time-consuming.
@@ -446,7 +446,7 @@ In order to maintain sym file integrity the following method is used to ensure a
 ```
 
 :fontawesome-regular-map:
-White paper: [Working with symfiles](../symfiles.md)
+[Working with symfiles](../symfiles.md)
 
 
 ### Step 4: Indexing
@@ -545,7 +545,6 @@ In order to reduce downtime between batches, each worker is killed and restarted
 Once the batch successfully completes, any post-ingestion event-driven tasks can be run. These can include any scheduled reporting, regulatory reporting for surveillance, transaction analysis, or ad-hoc queries.
 
 :fontawesome-regular-map:
-White papers:<br>
 [Surveillance techniques to effectively monitor algo- and high-frequency trading](../surveillance/index.md)<br>
 [Transaction-cost analysis using kdb+](../transaction-cost.md)
 

--- a/docs/wp/data-loaders/index.md
+++ b/docs/wp/data-loaders/index.md
@@ -1,21 +1,13 @@
 ---
-title: Mass ingestion through kdb+ data loaders | White papers | kdb+ and q documentation
+title: Mass ingestion through kdb+ data loaders | kdb+ and q documentation
 description: A fast, efficient and scalable kdb+ framework for receiving large amounts of data from multiple sources in various formats 
 author: Enda Gildea
 keywords: attribute, batch, data, disk, file, format, ingest, loader, sort
 ---
-White paper
-{: #wp-brand}
-
 # Mass ingestion through data loaders
 
 by [Enda Gildea](#author)
 {: .wp-author}
-
-
-
-
-
 
 
 Receiving a large amount of data in various file formats and from multiple different sources that need to be ingested, processed, persisted, and reported upon within a certain time period is a challenging task.

--- a/docs/wp/data-management.md
+++ b/docs/wp/data-management.md
@@ -1,20 +1,14 @@
 ---
-title: kdb+ data-management techniques | White papers | q and kdb+ documentation
+title: kdb+ data-management techniques | q and kdb+ documentation
 description: Examines implementation options and data-management techniques in seven scenarios
 author: Simon Mescal
 date: January 2013
 keywords: attribute, data management, grouped, intra-day, historical, kdb+, partitioned, performance, q, real-time, sorted, unique
 ---
-White paper
-{: #wp-brand}
-
 # kdb+ data-management techniques
 
 by [Simon Mescal](#author)
 {: .wp-author}
-
-
-
 
 
 

--- a/docs/wp/data-recovery.md
+++ b/docs/wp/data-recovery.md
@@ -1,18 +1,14 @@
 ---
-title: Data recovery for kdb+tick | White Papers | kdb+ and q documentation
+title: Data recovery for kdb+tick | kdb+ and q documentation
 description: Tickerplant logfiles can be replayed to recover service, even after they have been corrupted. 
 author: Fionnbharr Gaston
 date: July 2014
 keywords: corrupt, data, data recovery, error, kdb+, log, logfile, q, real-time, recovery, replay, subscribe, tick, tickerplant, trap
 ---
-White paper
-{: #wp-brand}
-
 # Data recovery for kdb+tick
 
 by [Fionnbharr Gaston](#author)
 {: .wp-author}
-
 
 
 

--- a/docs/wp/data-recovery.md
+++ b/docs/wp/data-recovery.md
@@ -44,7 +44,6 @@ Historical database
 : The historical database (HDB) consists of on-disk kdb+ data, typically split into date partitions. A kdb+ process can read this data and memory-map it, allowing for fast queries across a large volume of data. The RDB is instructed to save its data to the HDB at EOD.
 
 :fontawesome-regular-hand-point-right:
-White paper: 
 [kdb+ tick profiling for throughput optimization](tick-profiling.md)
 
 This paper will primarily consider the relationship between the TP and RDB and in particular the use of tickerplant logs when recovering lost data in an RDB.

--- a/docs/wp/data-visualization/index.md
+++ b/docs/wp/data-visualization/index.md
@@ -1,20 +1,14 @@
 ---
-title: "Data visualization with kdb+ using ODBC: a Tableau case study | White Papers | kdb+ and q documentation"
+title: "Data visualization with kdb+ using ODBC: a Tableau case study | kdb+ and q documentation"
 description: Illustrates the flexibility with which kdb+ data can be accessed by Tableau using ODBC
 author: Michaela Woods
 date: July 2018
 keywords: data, kdb+, ODBC, Tableau, visualization
 ---
-White paper
-{: #wp-brand}
-
 # Data visualization with kdb+ using ODBC: <br/>A Tableau case study
 
 by [Michaela Woods](#author)
 {: .wp-author}
-
-
-
 
 
 Business intelligence (BI) tools are widely used across many industries

--- a/docs/wp/disaster-floods/index.md
+++ b/docs/wp/disaster-floods/index.md
@@ -1,20 +1,14 @@
 ---
-title: Predicting floods with q and machine learning | White paper | kdb+ and q documentation
+title: Predicting floods with q and machine learning | kdb+ and q documentation
 description: Machine-learning methods in q to predict flood susceptibility in an area and the time for a river to reach its peak height after a rainfall event.
 author: Diane O’Donoghue
 date: October 2019
 keywords: embedpy, flash, flood, kdb+, machine learning, model, nasa, nhdplus, nlcd, noaa, prism, q, random forest, space, usgs, xgboost
 ---
-White paper
-{: #wp-brand}
-
 # Predicting floods with q and machine learning
 
 by [Diane O’Donoghue](#author)
 {: .wp-author}
-
-
-
 
 
 The Frontier Development Lab (FDL) is a public-private partnership run annually with both the European Space Agency (ESA) and National Aeronautics and Space Administration (NASA). The objective of FDL is to bring together researchers from the Artificial Intelligence (AI) and space science sectors to tackle a broad spectrum of challenges in the space industry. The projects this year include challenges in lunar and heliophysics research, astronaut health and disaster prevention. This paper will focus on the Disaster Prevention, Progress and Response (Floods) challenge, for which KX was a partner.

--- a/docs/wp/disaster-management/index.md
+++ b/docs/wp/disaster-management/index.md
@@ -1,18 +1,14 @@
 ---
-title: "FDL Europe: Analyzing social media data for disaster management | White papers | q and kdb+ documentation"
+title: "FDL Europe: Analyzing social media data for disaster management | q and kdb+ documentation"
 description: Deep-learning methods to classify tweets relating to flooding events – training a binary classifier to discern relevance; a categorical model to classify tweets into finer-grained buckets.
 author: Conor McCarthy
 date: October 2019
 keywords: disaster, kdb+, machine-learning, nasa, q, space, social media
 ---
-White paper
-{: #wp-brand}
-
 # FDL Europe: Analyzing social media data for disaster management
 
 by [Conor McCarthy](#author)
 {: .wp-author}
-
 
 
 

--- a/docs/wp/disaster-recovery/index.md
+++ b/docs/wp/disaster-recovery/index.md
@@ -90,7 +90,7 @@ split into date partitions. A q process can read this data and
 memory-map it, allowing for fast queries across a large volume of
 data. The RDB is instructed to save its data to the HDB at EOD (end of day).
 
-:fontawesome-regular-hand-point-right: White paper:
+:fontawesome-regular-hand-point-right: 
 [Data Recovery for kdb+ tick](../data-recovery.md)
 
 
@@ -270,7 +270,7 @@ carefully manage any querying of the database.
 
 ![](img/image12.jpeg)
 
-:fontawesome-regular-hand-point-right: White paper –
+:fontawesome-regular-hand-point-right: 
 [Query Routing: a kdb+ framework for a scalable load-balanced system](../query-routing/index.md)
 
 As mentioned above, the usual strategy for failover is to have a

--- a/docs/wp/disaster-recovery/index.md
+++ b/docs/wp/disaster-recovery/index.md
@@ -365,7 +365,7 @@ gateway queries should continue to be routed to the secondary until
 recovery and failover are complete, and the primary RDB is available
 to capture data and serve queries again.
 
-:fontawesome-regular-hand-point-right: White paper 
+:fontawesome-regular-hand-point-right:  
 [Data recovery for kdb+tick](../data-recovery.md)
 for a complete understanding of the recovery from a tickerplant log
 file, including how to deal with a corrupted log file

--- a/docs/wp/disaster-recovery/index.md
+++ b/docs/wp/disaster-recovery/index.md
@@ -1,17 +1,13 @@
 ---
-title: Disaster-recovery planning for kdb+ tick systems | White Papers | kdb+ and q documentation
+title: Disaster-recovery planning for kdb+ tick systems | kdb+ and q documentation
 description: Disaster recovery (DR) and failover concepts from the perspective of the gateway layer accessing a typical kdb+ tick system used in capital-markets applications
 author: Stewart Robinson
 keywords: disaster, failover, kdb+, planning, recovery, tick
 ---
-White paper
-{: #wp-brand}
-
 # Disaster-recovery planning for kdb+ tick systems
 
 by [Stewart Robinson](#author)
 {: .wp-author}
-
 
 
 

--- a/docs/wp/embedpy-lasso/index.md
+++ b/docs/wp/embedpy-lasso/index.md
@@ -1,19 +1,13 @@
 ---
-title: "Machine learning: Using embedPy to apply LASSO regression | White Papers | kdb+ and q documentation"
+title: "Machine learning: Using embedPy to apply LASSO regression | kdb+ and q documentation"
 description: From its deep roots in financial technology KX is expanding into new fields. It is important for q to communicate seamlessly with other technologies. The embedPy interface allows this to be done with Python.
 author: Samantha Gallagher
 date: October 2018
 ---
-White paper
-{: #wp-brand}
-
 # Machine learning: <br/>Using embedPy to apply LASSO regression
 
 by [Samantha Gallagher](#author)
 {: .wp-author}
-
-
-
 
 
 From its deep roots in financial technology KX is expanding into new fields.

--- a/docs/wp/exoplanets/index.md
+++ b/docs/wp/exoplanets/index.md
@@ -1,22 +1,14 @@
 ---
-title: NASA Frontier Development Lab Exoplanets Challenge | White Papers | kdb+ and q documentation
+title: NASA Frontier Development Lab Exoplanets Challenge | kdb+ and q documentation
 description: The Transiting Exoplanet Survey Satellite (TESS) was launched in April 2018, with the objective of discovering new exoplanets in orbit around the brightest stars in the solar neighborhood
 keywords: kdb+, q, space, NASA, machine learning
 author: Esperanza López Aguilera
 date: December 2018
 ---
-White paper
-{: #wp-brand}
-
 # NASA Frontier Development Lab Exoplanets Challenge
 
 by [Esperanza López Aguilera](#author)
 {: .wp-author}
-
-
-
-
-
 
 
 The NASA Frontier Development Lab (FDL) is an applied artificial intelligence (AI) research accelerator, hosted by the SETI Institute in partnership with NASA Ames Research Centre. The programme brings commercial and private partners together with researchers to solve challenges in the space science community using new AI technologies.

--- a/docs/wp/fix-messaging.md
+++ b/docs/wp/fix-messaging.md
@@ -1,23 +1,14 @@
 ---
-title: kdb+ and FIX messaging | White Papers | q and kdb+ documentation
+title: kdb+ and FIX messaging | q and kdb+ documentation
 description: A guide to working with FIX messages in kdb+, focusing primarily on capturing messages from an order-management system
 author: Damien Barker
 date: January 2014
 keywords: analytics, fix, kdb+, last order, order-management system, order processing, order status, 
 ---
-White paper
-{: #wp-brand}
-
 # kdb+ and FIX messaging
 
 by [Damien Barker](#author)
 {: .wp-author}
-
-
-
-
-
-
 
 
 Electronic trading volumes have increased significantly in recent years, prompting financial institutions, both buy and sell side, to invest in increasingly sophisticated Order Management Systems (OMS). OMSs efficiently manage the execution of orders using a set of pre-defined conditions to obtain the best price of execution. OMSs typically use the Financial Information eXchange (FIX) protocol, which has become the industry standard for electronic trade messaging since it was first developed in 1992.

--- a/docs/wp/foreign-keys.md
+++ b/docs/wp/foreign-keys.md
@@ -1,18 +1,14 @@
 ---
-title: The application of foreign keys and linked columns in kdb+ | White papers | q and kdb+ documentation
+title: The application of foreign keys and linked columns in kdb+ | q and kdb+ documentation
 description: How foreign keys and linked columns may be established and applied in kdb+ databases, and a review of the advantages and penalties
 author: Kevin Smyth
 date: April 2013
 keywords: foreign key, kdb+, link, linked columns, q, sym file, symlink
 ---
-White paper
-{: #wp-brand}
-
 # The application of foreign keys and linked columns in kdb+
 
 by [Kevin Smyth](#author)
 {: .wp-author}
-
 
 
 

--- a/docs/wp/gateway-design/index.md
+++ b/docs/wp/gateway-design/index.md
@@ -1,21 +1,13 @@
 ---
-title: Common design principles in kdb+ gateways | White paper | q and kdb+ documentation
+title: Common design principles in kdb+ gateways | q and kdb+ documentation
 description: The most common technical challenges associated with gateways and the reasoning behind various design options
 date: December 2012
 author: Michael McClintock
 ---
-White paper
-{: #wp-brand}
-
 # Common design principles for kdb+ gateways
 
 by [Michael McClintock](#author)
 {: .wp-author}
-
-
-
-
-
 
 
 In the vast majority of kdb+ systems, data is stored across several processes. These setups can range from a single real-time and historic database on the same server to multi-site architectures where data of various forms is stored in hundreds of different processes. In either scenario there is likely to be the same requirement to access data across processes. This is typically achieved using a ‘gateway’ process.

--- a/docs/wp/gui/index.md
+++ b/docs/wp/gui/index.md
@@ -1,19 +1,14 @@
 ---
-title: An introduction to graphical interfaces for kdb+ using C# | White Papers | kdb+ and q documentation
+title: An introduction to graphical interfaces for kdb+ using C# | kdb+ and q documentation
 description: Basics of using C# to open connections to kdb+ processes running on remote servers as well as setting up a basic API that will allow for authentication, error recovery and basic queries through an interface
 author: Michael Reynolds
 date: May 2013
 keywords: analytics, connections, csharp, gui, kdb+, queries, validation
 ---
-White paper
-{: #wp-brand}
-
 # An introduction to graphical interfaces for kdb+ using C&#35;
 
 by [Michael Reynolds](#author)
 {: .wp-author}
-
-
 
 
 Over the course of fifteen years, C# has become one of the most

--- a/docs/wp/gui/index.md
+++ b/docs/wp/gui/index.md
@@ -272,7 +272,7 @@ process. Within C#, this will throw a KException with the message
 access in the C# API.
 
 :fontawesome-regular-hand-point-right: 
-Tom Martin’s white paper [“Permissions with kdb+”](../permissions/index.md)
+[“Permissions with kdb+”](../permissions/index.md)
 for more detailed information on validation and authentication
 
 ```csharp

--- a/docs/wp/intraday-writedown/index.md
+++ b/docs/wp/intraday-writedown/index.md
@@ -1,19 +1,14 @@
 ---
-title: Intraday writedown solutions | White papers | q and kdb+ documentation
+title: Intraday writedown solutions | q and kdb+ documentation
 description: Compares two methods for dealing with insufficient RAM on a server, when a full day’s worth of data cannot be held in memory. 
 author: Colm McCarthy
 date: March 2014
 keywords: end of day, eod, hdb, intraday, kdb+, partition, performance, q, query speed, rdb, save, tick, write
 ---
-White paper
-{: #wp-brand}
-
 # Intraday writedown solutions
 
 by [Colm McCarthy](#author)
 {: .wp-author}
-
-
 
 
 With data volumes in the financial-services sector continuing to grow at exponential rates, kdb+ is the data-storage technology of choice for many financial institutions due to its efficiency in storing and retrieving large volumes of data. kdb+ is uniquely equipped to deal with these growing data volumes as it is extremely scalable and can deal with increasing data volumes with ease. As volumes grow the amount of data that can be kept in memory will eventually be limited by the RAM available on the server. There exist two types of solution to this problem.

--- a/docs/wp/iot-mqtt/index.md
+++ b/docs/wp/iot-mqtt/index.md
@@ -1,5 +1,5 @@
 ---
-title: Internet of Things with MQTT | White papers
+title: Internet of Things with MQTT
 description: MQTT is a messaging protocol for the Internet of Things (IoT). It was designed as an extremely lightweight publish/subscribe messaging transport. KX has released a MQTT interface with source code available on GitHub. The interface supports Linux, macOS, and Windows platforms.
 author: Rian Ó Cuinneagáin
 date: May 2021

--- a/docs/wp/ipc/index.md
+++ b/docs/wp/ipc/index.md
@@ -4,9 +4,6 @@ description: Core concepts related to IPC in kdb+, and the role of IPC in a kdb+
 author: Katrina McCormack
 date: April 2021
 ---
-White paper
-{: #wp-brand}
-
 # Interprocess communications
 
 by [Katrina McCormack](#author)

--- a/docs/wp/iterators/index.md
+++ b/docs/wp/iterators/index.md
@@ -1,19 +1,14 @@
 ---
-title: Iterators | White Papers | kdb+ and q documentation
+title: Iterators | kdb+ and q documentation
 description: Iterators (formerly known as adverbs) are the primary means of iteration in q, and in almost all cases the most efficient way to iterate. 
 author: [Conor Slattery, Stephen Taylor]
 date: March 2019
 keywords: accumulator, adverb, applicable value, converge, dictionary, do, iteration, iterator, kdb+, list, loop, map, operator, q, value, while
 ---
-White paper
-{: #wp-brand}
-
 # Iterators
 
 by [Conor Slattery &amp; Stephen Taylor](#authors)
 {: .wp-author}
-
-
 
 
 [Iterators](../../ref/iterators.md) (formerly known as _adverbs_) are the primary means of iteration in q, and in almost all cases the most efficient way to iterate. Loops are rare in q programs and are almost always candidates for optimization. Mastery of iterators is a core q skill.

--- a/docs/wp/lightning-tickerplants/index.md
+++ b/docs/wp/lightning-tickerplants/index.md
@@ -138,7 +138,7 @@ $sudo apt-get install bitcoind
 ```
 
 Before starting the daemon, a `bitcoin.conf` file should be created in the install folder (usually `$HOME/.bitcoin`),
-as described in white paper [Storing and exploring the Bitcoin blockchain](../blockchain/index.md#installing-a-bitcoin-full-node).
+as described in [Storing and exploring the Bitcoin blockchain](../blockchain/index.md#installing-a-bitcoin-full-node).
 However, the sample `bitcoin.conf` file presented in that white paper should now be extended, as shown below, to
 include the [ZeroMQ](https://github.com/bitcoin/bitcoin/blob/master/doc/zmq.md) wrapper, which will allow the Lightning
 node to be notified of events like the arrival of new blocks or transactions. Note that in the configuration file below, the
@@ -683,7 +683,6 @@ The main library functions this tickerplant implementation uses are shown below,
 form the basis for subsequent modifications. 
 
 :fontawesome-regular-hand-point-right:
-White paper: 
 [Building Real-Time Tick Subscribers](../rt-tick/index.md)
 
 ```q

--- a/docs/wp/lightning-tickerplants/index.md
+++ b/docs/wp/lightning-tickerplants/index.md
@@ -1,19 +1,14 @@
 ---
-title: "Lightning tickerplants: Pay-per-ticker with micropayments on the Lightning network | White Papers | kdb+ and q documentation"
+title: "Lightning tickerplants: Pay-per-ticker with micropayments on the Lightning network | kdb+ and q documentation"
 description: Use Lightning to monetize streaming data. Use the qlnd library to create payment channels, generate invoices, and route payments across the network.
 author: Jeremy Lucid
 date: August 2021
 keywords: bitcoin, lightning, blockchain, kdb+, q, tickerplant
 ---
-White paper
-{: #wp-brand}
-
 # Lightning tickerplants: Pay-per-ticker with micropayments on the Lightning network
 
 by [Jeremy Lucid](#author)
 {: .wp-author}
-
-
 
 
 [Lightning](https://lightning.network/lightning-network-paper.pdf) is a technology designed to scale Bitcoin and other compatible blockchains by enabling high transaction throughput with greater privacy while preserving decentralized qualities. It is a layer two infrastructure which builds upon the security and [smart contract](https://www.ucl.ac.uk/computer-science/research/research-groups/financial-computing-and-analytics/research/smart-contracts) functionality of the underlying base blockchain, analogous to how the HTTP application layer protocol builds on an underlying and reliable TCP layer. 

--- a/docs/wp/machine-learning/index.md
+++ b/docs/wp/machine-learning/index.md
@@ -1,22 +1,14 @@
 ---
-title: "Machine Learning in kdb+: k-Nearest Neighbor classification and pattern recognition with q | White papers | kdb+ and q documentation"
+title: "Machine Learning in kdb+: k-Nearest Neighbor classification and pattern recognition with q | kdb+ and q documentation"
 description: How to implement a k-NN classification algorithm with kdb+, using tables and qSQL, and iterators to optimize the classification time
 author: Emanuele Melis
 date: July 2017
 keywords: classifier, iterator, k-nearest-neighbor, kdb+, performance, q, qsql
 ---
-White paper
-{: #wp-brand}
-
 # Machine Learning in kdb+:<br>k-Nearest Neighbor classification and pattern recognition with q
 
 by [Emanuele Melis](#author)
 {: .wp-author}
-
-
-
-
-
 
 
 Amongst the numerous algorithms used in machine learning, k-Nearest Neighbors (k-NN) is often used in pattern recognition due to its easy implementation and non-parametric nature. A k-NN classifier aims to predict the class of an observation based on the prevailing class among its k-nearest neighbors; “nearest” is determined by a distance metric between class attributes (or features), and k is the number of nearest neighbors to consider.

--- a/docs/wp/market-depth/index.md
+++ b/docs/wp/market-depth/index.md
@@ -1,19 +1,14 @@
 ---
-title: Sample aggregation engine for market depth | White papers | kdb+ and q documentation
+title: Sample aggregation engine for market depth | kdb+ and q documentation
 description: A framework for aggregating market depth and managing multiple subscriptions, using FX data as an example
 author: Stephen Dempsey
 date: January 2014
 keywords: aggregation, ask, attribute, bid, book, depth, fx, kdb+, market depth, order book, price,publish, q, quote, schema, sort, subscribe, top of book
 ---
-White paper
-{: #wp-brand}
-
 # Sample aggregation engine for market depth
 
 by [Stephen Dempsey](#author)
 {: .wp-author}
-
-
 
 
 Throughout the past decade the volume of data in the financial markets has increased substantially due to a variety of factors, including access to technology, decimalization and increased volatility. As these volumes increase it can pose significant problems for applications consuming market depth, which is summarized as the quantity of the instrument on offer at each price level. The purpose of this white paper is to describe a sample method for efficiently storing and producing views on this depth data.

--- a/docs/wp/market-fragmentation/index.md
+++ b/docs/wp/market-fragmentation/index.md
@@ -1,18 +1,14 @@
 ---
-title: "Market Fragmentation:  A kdb+ framework for multiple liquidity sources | White Papers | kdb+ and q documentation"
+title: "Market Fragmentation:  A kdb+ framework for multiple liquidity sources | kdb+ and q documentation"
 description: An approach to the challenge of consolidating share price information for equities that trade on multiple venues.
 author: James Corcoran
 date: January 2013
 keywords: analytics, fragmentation, kdb+, market
 ---
-White paper
-{: #wp-brand}
-
 # Market Fragmentation:<br/>A kdb+ framework for multiple liquidity sources
 
 by [James Corcoran](#author)
 {: .wp-author}
-
 
 
 

--- a/docs/wp/multi-partitioned-dbs/index.md
+++ b/docs/wp/multi-partitioned-dbs/index.md
@@ -1,19 +1,13 @@
 ---
-title: "Multi-partitioned kdb+ databases: an equity options case study | White Papers | kdb+ and q documentation"
+title: "Multi-partitioned kdb+ databases: an equity options case study | kdb+ and q documentation"
 description: Storage and maintenance of financial equity options data in kdb+, with examples of possible ways to design and query these large databases efficiently.
 author: James Hanna
 keywords: database, equity, kdb+, options, partition, 
 ---
-White paper
-{: #wp-brand}
-
 # Multi-partitioned kdb+ databases: <br/>an equity options case study
 
 by [James Hanna](#author)
 {: .wp-author}
-
-
-
 
 
 kdb+ is well suited to managing massive datasets and offers an

--- a/docs/wp/multi-thread/index.md
+++ b/docs/wp/multi-thread/index.md
@@ -1,19 +1,13 @@
 ---
-title: Multi-threading in kdb+ | White Papers | kdb+ and q documentation
+title: Multi-threading in kdb+ | kdb+ and q documentation
 description: How to use parallel processing in kdb+ processes, and what the limitations are
 author: Edward Cormack
 keywords: kdb+, multi-core, multi-threading, parallel, parallelize, performance, q, vector
 ---
-White paper
-{: #wp-brand}
-
 # Multi-threading in kdb+<br>Performance optimizations and use cases
 
 by [Edward Cormack](#author)
 {: .wp-author}
-
-
-
 
 
 

--- a/docs/wp/neural-networks/index.md
+++ b/docs/wp/neural-networks/index.md
@@ -1,19 +1,13 @@
 ---
-title: An introduction to neural networks with kdb+ | White Papers | kdb+ and q documentation
+title: An introduction to neural networks with kdb+ | kdb+ and q documentation
 description: Implementation of a feedforward neural network in kdb+
 author: James Neill
 keywords: kdb+, neural network
 ---
-White paper
-{: #wp-brand}
-
 # An introduction to neural networks with kdb+
 
 by [James Neill](#author)
 {: .wp-author}
-
-
-
 
 
 Due to the desire to understand the brain and mimic the way it works

--- a/docs/wp/option-pricing/index.md
+++ b/docs/wp/option-pricing/index.md
@@ -1,19 +1,14 @@
 ---
-title: Sobol’ option pricing in q | White papers | kdb+ and q documentation
+title: Sobol’ option pricing in q | kdb+ and q documentation
 description: Monte Carlo (MC) and Quasi-Monte Carlo (QMC) methods for pricing European and Asian options, with standard discretization and Brownian-bridge construction
 author: Deanna Morgan
 date: October 2019
 keywords: asian, black-scholes, c++, european, kdb+, monte carlo, option pricing, q, sobol,
 ---
-White paper
-{: #wp-brand}
-
 # Comparing option pricing methods in q
 
 by [Deanna Morgan](#author)
 {: .wp-author}
-
-
 
 
 In this paper, we compare the use of both Monte Carlo (MC) and Quasi-Monte Carlo (QMC) methods in the process of pricing European and Asian options. In doing so, we consider the use of two discretization schemes - standard discretization and Brownian-bridge construction. Results produced by the different methods are compared with the deterministic Black-Scholes price for each option type, using Global Sensitivity Analysis (SA). Note that the methods demonstrated below follow the work presented by [S. Kucherenko et al. 2007](http://www.broda.co.uk/gsa/wilmott_GSA_SK.pdf "Wilmott").

--- a/docs/wp/order-book.md
+++ b/docs/wp/order-book.md
@@ -5,15 +5,10 @@ author: Niall Coulter
 date: April 2012
 keywords: access, kdb+, latency, performance, q, storage
 ---
-White paper
-{: #wp-brand}
-
 # Order Book: a kdb+ intraday storage and access methodology
 
 by [Niall Coulter](#author)
 {: .wp-author}
-
-
 
 
 The purpose of this white paper is to describe some of the structures available for storing a real-time view of an order book in kdb+ and to provide some examples of how to query each of these structures effectively.

--- a/docs/wp/order-book.md
+++ b/docs/wp/order-book.md
@@ -1,5 +1,5 @@
 ---
-title: "Order Book: a kdb+ intraday storage and access methodology | White papers | q and kdb+ documentation"
+title: "Order Book: a kdb+ intraday storage and access methodology | q and kdb+ documentation"
 description: Strategies for storing order-book data, and their implications for query performance
 author: Niall Coulter
 date: April 2012

--- a/docs/wp/parse-trees.md
+++ b/docs/wp/parse-trees.md
@@ -4,14 +4,10 @@ description: How to understand parse trees and use functional forms in q queries
 author: [Peter Storeng, Stephen Taylor]
 keywords: functional, kdb+, parse, parse tree, q, qSQL, query, SQL
 ---
-White paper
-{: #wp-brand}
-
 # Parse trees and functional forms
 
 by [Peter Storeng &amp; Stephen Taylor](#authors)
 {: .wp-author}
-
 
 
 The importance of understanding and using the functional form of qSQL statements in kdb+ cannot be overstated. The functional form has many advantages over the qSQL approach, including the ability to select columns and build Where clauses dynamically. It is important for any q programmer to understand the functional form fully and how to convert to it from qSQL.

--- a/docs/wp/parse-trees.md
+++ b/docs/wp/parse-trees.md
@@ -1,5 +1,5 @@
 ---
-title: Parse trees and functional forms | White Paper | kdb+ and q documentation
+title: Parse trees and functional forms | kdb+ and q documentation
 description: How to understand parse trees and use functional forms in q queries; how to convert qSQL expressions to functional form.
 author: [Peter Storeng, Stephen Taylor]
 keywords: functional, kdb+, parse, parse tree, q, qSQL, query, SQL
@@ -286,7 +286,7 @@ remaining items. Here `/` (the Over iterator) is applied to `+` to
 produce a new function which sums the items of a list.
 
 :fontawesome-regular-hand-point-right:
-White paper: [Iterators](iterators/index.md)
+[Iterators](iterators/index.md)
 
 
 ## Functional queries

--- a/docs/wp/permissions/index.md
+++ b/docs/wp/permissions/index.md
@@ -1,13 +1,10 @@
 ---
-title: Permissions with kdb+ | White papers | q and kdb+ documentation
+title: Permissions with kdb+ | q and kdb+ documentation
 description: An introduction to permissioning in kdb+ without using LDAP or any other external entitlements system
 author: Tom Martin
 date: May 2013
 keywords: access, authentication, code injection, database, entitlement, http, ipc, kdb+, kerberos, ldap, password, permission, poweruser, q, query, security, single sign-on, superuser, user
 ---
-White paper
-{: #wp-brand}
-
 # Permissions with kdb+
 
 by [Tom Martin](#author)

--- a/docs/wp/query-interface.md
+++ b/docs/wp/query-interface.md
@@ -1,19 +1,14 @@
 ---
-title: A natural query interface for distributed systems | White papers | kdb+ and q documentation
+title: A natural query interface for distributed systems | kdb+ and q documentation
 description: An interface similar to q for queries to kdb+ tables distributed across multiple systems, implemented in q, trading some q optimizations for convenience 
 author: Sean Keevey
 date: November 2014
 keywords: distributed systems, kdb+, natural, q, query
 ---
-White paper
-{: #wp-brand}
-
 # A natural query interface for distributed systems
 
 by [Sean Keevey](#author)
 {: .wp-author}
-
-
 
 
 Technical constraints mean that large real-time database installations tend to be distributed over many processes and machines. In an environment where end-users need to be able to query the data directly, this poses a challenge – they must find the location of the data and connect before they can query it. Typically this inconvenience is mitigated by providing an API. This can take the form of a function which can be used to query tables in the data warehouse.

--- a/docs/wp/query-routing/index.md
+++ b/docs/wp/query-routing/index.md
@@ -20,7 +20,7 @@ Distributed kdb+ systems have been covered in a number of KX Technical
 White papers. The primary objective of this paper is to expand on
 routing, query tagging and connectivity management of a large
 distributing kdb+ system. The basic architecture used in this paper is
-based heavily on the ideas discussed in another white paper:
+based heavily on the ideas discussed in 
 [“Common design principles for kdb+ gateways”](../gateway-design/index.md).
 
 It is recommended the reader understand these concepts before
@@ -212,8 +212,8 @@ matching the name passed to `userQuery` and send an error if no such
 resource exists. We are setting outside the scope of this paper any
 further request validation, including access permissioning. 
 
-For further details on access control, please refer to the technical
-white paper [“Permissions with kdb+”](../permissions/index.md).
+For further details on access control, please refer to 
+[“Permissions with kdb+”](../permissions/index.md).
 
 When a user sends her query via the `userQuery` function, we assign
 the query a unique sequence number and publish an asynchronous
@@ -617,8 +617,8 @@ As an example framework focused on network routing, this paper covers
 much of the core functionality, but the scope of this paper does not
 encompass some desirable production features a system architect should
 consider, such as permissions, query validation and capacity
-management. Where topics haven’t been covered previously, the KX
-Technical White paper series will continue to drill down on important
+management. Where topics haven’t been covered previously, KX 
+will continue to drill down on important
 components that provide the building blocks for a stable, scalable,
 protected and efficient kdb+ system.
 

--- a/docs/wp/query-routing/index.md
+++ b/docs/wp/query-routing/index.md
@@ -1,20 +1,14 @@
 ---
-title: "Query Routing: a kdb+ framework for a scalable, load balanced system | White Papers | kdb+ and q documentation"
+title: "Query Routing: a kdb+ framework for a scalable, load balanced system | kdb+ and q documentation"
 description: The design principle of the Connection Manager Load Balancer schematic whilst providing an asynchronous-only method of communication between processes.
 author: Kevin Holsgrove
 date: November 2015
 keywords: query, routing, load, balancing, kdb+, gateway
 ---
-White paper
-{: #wp-brand}
-
 # Query Routing: A kdb+ framework for a scalable, load balanced system
 
 by [Kevin Holsgrove](#author)
 {: .wp-author}
-
-
-
 
 
 Due to the large scale that kdb+ systems commonly grow to, it is

--- a/docs/wp/query-scaling.md
+++ b/docs/wp/query-scaling.md
@@ -1,21 +1,14 @@
 ---
-title: kdb+ query scaling | White papers | kdb+ and q documentation
+title: kdb+ query scaling | kdb+ and q documentation
 description: How to take advantage of multiple kdb+ query structures  to achieve optimal query performance for large volumes of data
 author: Ian Lester
 date: January 2014
 keywords: find, join, kdb+, optimize, performance, q, query, scale, select
 ---
-White paper
-{: #wp-brand}
-
 # kdb+ query scaling
 
 by [Ian lester](#author)
 {: .wp-author}
-
-
-
-
 
 
 Trading volumes in financial market exchanges have increased significantly in recent years and as a result it has become increasingly important for financial institutions to invest in the best technologies and to ensure that they are used to their full potential.

--- a/docs/wp/rt-tick/index.md
+++ b/docs/wp/rt-tick/index.md
@@ -1,20 +1,14 @@
 ---
-title: Building real-time tick subscribers | White Papers | kdb+ and q documentation
+title: Building real-time tick subscribers | kdb+ and q documentation
 description: How to build a custom real-time tick subscriber
 author: Nathan Perrem
 date: August 2014
 keywords: kdb+, q, real-time, subscribe, tick
 ---
-White paper
-{: #wp-brand}
-
 # Building real-time tick subscribers
 
 by [Nathan Perrem](#author)
 {: .wp-author}
-
-
-
 
 The purpose of this white paper is to help q developers who wish to build their own custom real-time tick subscribers. KX provides kdb+tick, a tick capture system which includes the core q code for the tickerplant process (`tick.q`) and the vanilla real-time subscriber process (`r.q`), known as the real-time database. This vanilla real-time process subscribes to all tables and to all symbols on the tickerplant. This process has very simple behavior upon incoming updates – it simply inserts these records to the end of the corresponding table. This may be perfectly useful to some clients, however what if the client requires more interesting functionality? For example, the client may need to build or maintain their queries or analytics in real time. How would one take `r.q` and modify it to achieve said behavior? This white paper attempts to help with this task. It breaks down into the following broad sections:
 

--- a/docs/wp/rt-tick/index.md
+++ b/docs/wp/rt-tick/index.md
@@ -347,7 +347,7 @@ This attempt at logfile replay failed because the data is a list, not a table, a
 
 The real-time database (`r.q`) replays the tickerplant logfile upon startup. Specifically, after it has connected/subscribed to the tickerplant, but before it has received any intraday updates.
 
-For more information on tickerplant logfile replay, see White Paper [“Data Recovery for kdb+tick”](../data-recovery.md) published in July 2014, written by Fionnbharr Gaston.
+For more information on tickerplant logfile replay, see [“Data Recovery for kdb+tick”](../data-recovery.md) published in July 2014, written by Fionnbharr Gaston.
 
 
 ### End of day

--- a/docs/wp/signal-processing/index.md
+++ b/docs/wp/signal-processing/index.md
@@ -1,19 +1,14 @@
 ---
-title: Signal processing and q | White Papers | kdb+ and q documentation
+title: Signal processing and q | kdb+ and q documentation
 description: How statistical signal-processing operations can be implemented within q to remove noise, extract useful information, and quickly identify anomalies
 keywords: kdb+, processing, q, signal
 author: Callum Biggs
 date: August 2018
 ---
-White paper
-{: #wp-brand}
-
 # Signal processing and q
 
 by [Callum Biggs](#author)
 {: .wp-author}
-
-
 
 
 

--- a/docs/wp/socket-sharding/index.md
+++ b/docs/wp/socket-sharding/index.md
@@ -1,19 +1,14 @@
 ---
-title: Socket sharding with kdb+ and Linux | White Papers | kdb+ and q documentation
+title: Socket sharding with kdb+ and Linux | kdb+ and q documentation
 description: Set-up and use of socket sharding in kdb+, with several example scenarios
 author: Marcus Clarke
 date: January 2018
 keywords: gateway, linux, load balance, port, shard, socket, so_reuseport
 ---
-White paper
-{: #wp-brand}
-
 # Socket sharding with kdb+ and Linux
 
 by [Marcus Clarke](#author)
 {: .wp-author}
-
-
 
 
 When creating a new TCP socket on a Linux server several options can be set which affect the behavior of the newly-created socket. One of these options, `SO_REUSEPORT`, allows multiple sockets to bind to the same local IP address and port. Incoming connection requests to this port number are allocated by the Linux kernel to a listening process, allowing user queries to be spread across multiple processes while providing a single connection port to users and without requiring users to go through a load balancer.

--- a/docs/wp/solace/index.md
+++ b/docs/wp/solace/index.md
@@ -4,15 +4,10 @@ description: Set-up and use of socket sharding in kdb+, with several example sce
 author: Himanshu Gupta
 date: November 2020
 ---
-White paper
-{: #wp-brand}
-
 # Publish-subscribe messaging with Solace
 
 by [Himanshu Gupta](#author)
 {: .wp-author}
-
-
 
 
 ![](img/pub_sub.png)

--- a/docs/wp/solace/index.md
+++ b/docs/wp/solace/index.md
@@ -1,5 +1,5 @@
 ---
-title: Publish-subscribe messaging with Solace | White papers | kdb+ and q documentation
+title: Publish-subscribe messaging with Solace | kdb+ and q documentation
 description: Set-up and use of socket sharding in kdb+, with several example scenarios
 author: Himanshu Gupta
 date: November 2020

--- a/docs/wp/space-weather/index.md
+++ b/docs/wp/space-weather/index.md
@@ -1,18 +1,14 @@
 ---
-title: NASA Frontier Development Lab Space Weather Challenge | White Papers | kdb+ and q documentation
+title: NASA Frontier Development Lab Space Weather Challenge | kdb+ and q documentation
 description: Examines the use of ML models to predict scintillation events, using historical GNSS data
 author: Deanna Morgan
 date: November 2018
 keywords: kdb+, q, space, NASA, machine learning
 ---
-White paper
-{: #wp-brand}
-
 # NASA Frontier Development Lab Space Weather Challenge
 
 by [Deanna Morgan](#author)
 {: .wp-author}
-
 
 
 

--- a/docs/wp/surv-cloud/index.md
+++ b/docs/wp/surv-cloud/index.md
@@ -4,9 +4,6 @@ title: Surveillance in the Cloud
 description: Trade surveillance systems analyze up to terabytes of order and trade data daily, in an effort to detect potential market abuses. 
 date: April 2022
 ---
-White paper
-{: #wp-brand}
-
 # Surveillance in the Cloud
 
 ![banner](./img/banner.jpg)

--- a/docs/wp/surveillance-latency/index.md
+++ b/docs/wp/surveillance-latency/index.md
@@ -293,7 +293,7 @@ In graphical form, these are presented as:
 
 In this case, the memory usage is similar if not identical to that in experiment 1 – to be expected given that the data is the same. The run times behave the same across the execution points as previously i.e. grows as execution point is less frequent and appears to take slightly longer than when the data is streaming. Although the run time of the iterative approach in the real-time case is in line with the other approaches, it is unacceptably long in the intraday cases and would lead to a lengthy time rerunning the alerts historical.
 
-We could experiment with the introduction of [parallel processing](../../basics/peach.md) into the framework. From the results in the white paper “[Multithreading in kdb+](../multi-thread/index.md)”, we would expect this to reduce the run-time and memory usage of the iterative approach. Although, not as much as to bring them down to those of the other three approaches without a considerable implementation revision. At this stage, we discount the iterative approach as an option as there is strong evidence that it would cause an unacceptable lag behind the streaming data which may require considerable efficiency-making efforts to overcome.
+We could experiment with the introduction of [parallel processing](../../basics/peach.md) into the framework. From the results in “[Multithreading in kdb+](../multi-thread/index.md)”, we would expect this to reduce the run-time and memory usage of the iterative approach. Although, not as much as to bring them down to those of the other three approaches without a considerable implementation revision. At this stage, we discount the iterative approach as an option as there is strong evidence that it would cause an unacceptable lag behind the streaming data which may require considerable efficiency-making efforts to overcome.
 
 As mentioned previously, in the section ‘Exchange-member simulation’, the grouping by cryptocurrency sym only is not seen as realistic. It is expected that institutional data will be grouped by combinations such as sym+traderID, sym+brokerID, sym+desk etc. Our final experiment tests the remaining three approaches on four hours of streaming data with simulated member IDs added to the data. We consider the following results to be more reflective of real institutional data:
 
@@ -334,7 +334,7 @@ These results show that the use of event ID windows instead of timestamp windows
 
 There are other factors that we have not experimented with – the distribution of the twenty runs of the alert analytics out to different secondary threads, implementing intraday memory management techniques in the alert engines or varying the hard-coded lookback threshold of five minutes on top of varying the intraday execution point frequency.
 
-Whether on the minimal grouping by sym or on an estimated realistic grouping of sym and member ID, the real-time execution results appear not to discount the possibility of the alert engine being regularly occupied while it attempts to catch up with the live streaming data. More careful examination of bucket-by-bucket results is required though, to truly qualify that finding. If so, this would affect the implementation of memory-management techniques or the scheduling of intraday/end-of-day activities within the alert engines as the lag could continuously build up over time (more applicable in the case of 24 streaming data as is used in these experiments). This ties in with the conclusions in the “[kdb+tick profiling for throughput optimization](../tick-profiling.md)” white paper, where it is found more efficient to deal with messages in bulk rather than in isolation – further justifying our dismissal of the iterative approach.
+Whether on the minimal grouping by sym or on an estimated realistic grouping of sym and member ID, the real-time execution results appear not to discount the possibility of the alert engine being regularly occupied while it attempts to catch up with the live streaming data. More careful examination of bucket-by-bucket results is required though, to truly qualify that finding. If so, this would affect the implementation of memory-management techniques or the scheduling of intraday/end-of-day activities within the alert engines as the lag could continuously build up over time (more applicable in the case of 24 streaming data as is used in these experiments). This ties in with the conclusions in “[kdb+tick profiling for throughput optimization](../tick-profiling.md)”, where it is found more efficient to deal with messages in bulk rather than in isolation – further justifying our dismissal of the iterative approach.
 
 On the other hand, the results suggest that the intraday approaches always finish their task in ample time before the next intraday milestone is reached – giving plenty of time for any memory management tasks or intraday/end-of-day job scheduling to complete in an expected timeframe. For example, the results suggest that any EOD job scheduled in an alert engine running on an intraday 1-minute basis will start at most at 00:07 after the last intraday bucket of the day has been analyzed by the 20 alert calls. This short delay could be further reduced by memory-management techniques and the use of secondary threads.
 
@@ -357,7 +357,7 @@ In conclusion, between what appears to be an acceptable guaranteed cap on the la
 
 ## Appendix – Surveillance framework example
 
-The white paper “[Building real-time tick subscribers](../rt-tick/index.md)”, demonstrates the ease with which a skeleton kdb+ ticker plant framework can be adapted to meet an organization’s specific needs. Taking this, we set up the following sample surveillance framework:
+“[Building real-time tick subscribers](../rt-tick/index.md)”, demonstrates the ease with which a skeleton kdb+ ticker plant framework can be adapted to meet an organization’s specific needs. Taking this, we set up the following sample surveillance framework:
 
 ![Example surveillance framework used for experimentation](img/figure6.png)
 
@@ -376,7 +376,7 @@ In addition, we have introduced a number of alert-engine processes subscribing t
 
 This framework is for the purposes of experimenting only and we do not suggest that this is an optimal TP setup for the above processes. Potentially we could have placed chained ticker plants between the main parent ticker plant and the alert engines.
 
-See white paper “[Building real-time tick subscribers](../rt-tick/index.md)” for details behind the startup scripts for the ticker plant, RDB and HDB processes. The main adjustment we made to those scripts was to define additional schemas in `sym.q`. These schemas are
+See “[Building real-time tick subscribers](../rt-tick/index.md)” for details behind the startup scripts for the ticker plant, RDB and HDB processes. The main adjustment we made to those scripts was to define additional schemas in `sym.q`. These schemas are
 
 schema | contents
 -------|----------

--- a/docs/wp/surveillance-latency/index.md
+++ b/docs/wp/surveillance-latency/index.md
@@ -1,19 +1,14 @@
 ---
-title: Latency and efficiency considerations for a real-time surveillance system | White papers | kdb+and q documentation
+title: Latency and efficiency considerations for a real-time surveillance system | kdb+and q documentation
 description: This paper investigates performance of four different alert analytic programming styles running at four different points of execution 
 author: Jason Quinn
 date: November 2019
 keywords: alerts, latency, realtime alert logic, surveillance  
 ---
-White paper
-{: #wp-brand}
-
 # Latency and efficiency considerations for a real-time surveillance system
 
 by [Jason Quinn](#author)
 {: .wp-author}
-
-
 
 
 The time between transaction execution and transaction monitoring against regulation guidelines varies across financial institutions. Factors such as the number of markets, the number of trading systems and their messaging profiles can play a significant part in deciding whether to run surveillance analytics on a real-time or an intraday/end-of day basis.

--- a/docs/wp/surveillance/index.md
+++ b/docs/wp/surveillance/index.md
@@ -1,13 +1,10 @@
 ---
-title: Surveillance techniques to effectively monitor algo and high-frequency trading | White Papers | kdb+ and q documentation
+title: Surveillance techniques to effectively monitor algo and high-frequency trading | kdb+ and q documentation
 author: [Sam Stanton-Cook, Ryan Sparks, Dan O’Riordan, Rob Hodgkinson]
 description: Surveillance techniques using kdb+ to monitor algorithmic and high-frequency trading, with examples from the Australian financial markets
 date: March 2014
 keywords: algorithmic, australia, high-frequency, regulator, surveillance
 ---
-White paper
-{: #wp-brand}
-
 # Surveillance techniques to effectively monitor algo- and high-frequency trading
 
 by [Sam Stanton-Cook, Ryan Sparks, Dan O’Riordan &amp; Rob Hodgkinson](#authors)

--- a/docs/wp/symfiles.md
+++ b/docs/wp/symfiles.md
@@ -1,21 +1,14 @@
 ---
-title: Working with sym files | White Papers | kdb+ and q documentation
+title: Working with sym files | kdb+ and q documentation
 description: What the sym file is, suggestions for table setup, the maintenance of the sym file and safety measures that can be taken to protect the sym file.
 author: Paula Clarke
 date: March 2019
 keywords: kdb+, q, sym, symfile
 ---
-White paper
-{: #wp-brand}
-
 # Working with sym files
 
 by [Paula Clarke](#author)
 {: .wp-author}
-
-
-
-
 
 As kdb+ developers we often find ourselves working with some of the
 largest and most important real-time and historical data sets in the

--- a/docs/wp/tick-profiling.md
+++ b/docs/wp/tick-profiling.md
@@ -1,18 +1,14 @@
 ---
-title: kdb+tick profiling for throughput optimization | White Papers | kdb+ and q documentation
+title: kdb+tick profiling for throughput optimization | kdb+ and q documentation
 description: Key factors that influence the performance and throughput of a kdb+ tickerplant, a methodology to profile its performance, and four key areas to control.
 author: Ian Kilpatrick
 date: March 2014
 keywords: chained tickerplant, frequency, kdb+, performance, publish, q, rdb, subscribers, tick, tickerplant, update
 ---
-White paper
-{: #wp-brand}
-
 # kdb+tick profiling for throughput optimization
 
 by [Ian Kilpatrick](#author)
 {: .wp-author}
-
 
 
 

--- a/docs/wp/transaction-cost.md
+++ b/docs/wp/transaction-cost.md
@@ -1,21 +1,14 @@
 ---
-title: Transaction-cost analysis using kdb+ | White papers | q and kdb+documentation
+title: Transaction-cost analysis using kdb+ | q and kdb+documentation
 author: Colm Earley
 date: December 2012
 description: Using kdb+to analyze transaction costs from high-frequency data that often overwhelms traditional database and event-processing systems
 keywords: analysis, performance, schema, transaction cost
 ---
-White paper
-{: #wp-brand}
-
 # Transaction-cost analysis using kdb+
 
 by [Colm Earley](#author)
 {: .wp-author}
-
-
-
-
 
 
 With the ever-increasing volatility of financial markets and multitude of trading venues as a result of market fragmentation, transaction-cost analysis (TCA) has become one of the expected functions provided to a client by their broker dealer. The buy side has also become more sophisticated in recent years in acquiring their own TCA tools as they seek more transparency around their trading. These firms now strive to measure their real execution performance, feeding statistics into their portfolio strategies, market-impact models and, of course, relaying their level of service satisfaction back to their brokers.

--- a/docs/wp/trend-indicators/index.md
+++ b/docs/wp/trend-indicators/index.md
@@ -1,12 +1,9 @@
 ﻿---
-title: Implementing trend indicators in kdb+  | White papers | Documentation for kdb+ and q
+title: Implementing trend indicators in kdb+ | Documentation for kdb+ and q
 author: James Galligan
 date: April 2020
 description: Using kdb+ to produce trade analytics – indicators and oscillators traders commonly use to trigger buy/sell signals and clarify their picture of the market.
 ---
-White paper
-{: #wp-brand}
-
 # Implementing trend indicators in kdb+
 
 by [James Galligan](#author)

--- a/docs/wp/ts-shrink/index.md
+++ b/docs/wp/ts-shrink/index.md
@@ -5,15 +5,10 @@ description: Two implementations of the Ramer-Douglas-Peucker algorithm for curv
 date: February 2015
 keywords: compression, distortion, iterative, kdb+, q, Ramer-Douglas-Peucker, recursive, simplification, time series
 ---
-White paper
-{: #wp-brand}
-
 # Dynamically shrinking big data using time-series database kdb+
 
 by [Sean Keevey &amp; Kevin Smyth](#author)
 {: .wp-author}
-
-
 
 
 

--- a/docs/wp/ts-shrink/index.md
+++ b/docs/wp/ts-shrink/index.md
@@ -1,5 +1,5 @@
 ---
-title: Dynamically shrinking big data using timeseries database kdb+ | White papers | q and kdb+ documentation
+title: Dynamically shrinking big data using timeseries database kdb+ | q and kdb+ documentation
 author: [Sean Keevey, Kevin Smyth]
 description: Two implementations of the Ramer-Douglas-Peucker algorithm for curve simplification applied to financial time-series data without distortion.
 date: February 2015

--- a/docs/wp/websockets/index.md
+++ b/docs/wp/websockets/index.md
@@ -1,19 +1,14 @@
 ---
-title: kdb+ and WebSockets | White Papers | kdb+ and q documentation
+title: kdb+ and WebSockets | kdb+ and q documentation
 description: What WebSockets are, what benefits they hold over standard HTTP; how to set up a simple web page that uses WebSockets to connect to a kdb+ process
 author: [Chris Scott, Michael Gracey]
 date: March 2018
 keywords: AJAX, asynchronous, connection, HTML5, JavaScript, security, WebSockets
 ---
-White paper
-{: #wp-brand}
-
 # kdb+ and WebSockets
 
 by [Chris Scott &amp; Michael Gracey](#authors)
 {: .wp-author}
-
-
 
 
 Since the release of kdb+ 3.0, it has been possible to make use of

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -178,21 +178,21 @@ nav:
         - Phrasebook: https://code.kx.com/phrases/
         - Scrabble: learn/reading/scrabble.md
       - Application examples:
-        - Astronomy (WP): wp/astronomy.md
-        - Bitcoin blockchains (WP): wp/blockchain/index.md
-        - Card counters (WP): wp/card-counters/index.md
-        - Corporate actions (WP): wp/corporate-actions.md
-        - Disaster management (WP): wp/disaster-management/index.md
-        - Exoplanets (WP): wp/exoplanets/index.md
-        - Market depth (WP): wp/market-depth/index.md
-        - Market fragmentation (WP): wp/market-fragmentation/index.md
-        - Option pricing (WP): wp/option-pricing/index.md
-        - Predicting floods (WP): wp/disaster-floods/index.md
-        - Signal processing (WP): wp/signal-processing/index.md
-        - Space weather (WP): wp/space-weather/index.md
-        - Trading surveillance (WP): wp/surveillance/index.md
-        - Transaction-cost analysis (WP): wp/transaction-cost.md
-        - Trend indicators (WP): wp/trend-indicators/index.md
+        - Astronomy: wp/astronomy.md
+        - Bitcoin blockchains: wp/blockchain/index.md
+        - Card counters: wp/card-counters/index.md
+        - Corporate actions: wp/corporate-actions.md
+        - Disaster management: wp/disaster-management/index.md
+        - Exoplanets: wp/exoplanets/index.md
+        - Market depth: wp/market-depth/index.md
+        - Market fragmentation: wp/market-fragmentation/index.md
+        - Option pricing: wp/option-pricing/index.md
+        - Predicting floods: wp/disaster-floods/index.md
+        - Signal processing: wp/signal-processing/index.md
+        - Space weather: wp/space-weather/index.md
+        - Trading surveillance: wp/surveillance/index.md
+        - Transaction-cost analysis: wp/transaction-cost.md
+        - Trend indicators: wp/trend-indicators/index.md
       - Advanced q:
         - Remarks on Style: https://github.com/qbists/style
         - Shifts & scans: learn/shifts-scans.md
@@ -217,7 +217,7 @@ nav:
         - Iterators: ref/iterators.md
         - Maps: ref/maps.md
         - Accumulators: ref/accumulators.md
-        - Guide to iterators (WP): wp/iterators/index.md
+        - Guide to iterators: wp/iterators/index.md
       - Keywords:
         - abs: ref/abs.md
         - aj, aj0, ajf, ajf0: ref/aj.md
@@ -419,7 +419,7 @@ nav:
       - Metadata: basics/metadata.md
       - Namespaces: basics/namespaces.md
       - Parse trees: basics/parsetrees.md
-      - Parse trees, functional SQL (WP): wp/parse-trees.md
+      - Parse trees, functional SQL: wp/parse-trees.md
       - QSQL queries: basics/qsql.md
       - Regular Expressions: basics/regex.md
       - Syntax: basics/syntax.md
@@ -430,27 +430,27 @@ nav:
       - Tables in the filesystem: database/index.md
       - Populating tables:
         - Loading from large files: kb/loading-from-large-files.md
-        - Foreign keys (WP): wp/foreign-keys.md
+        - Foreign keys: wp/foreign-keys.md
         - Linking columns: kb/linking-columns.md
-        - Data loaders (WP): wp/data-loaders/index.md
+        - Data loaders: wp/data-loaders/index.md
         - From MDB via ODBC: database/mdb-odbc.md
       - Persisting tables:
         - Serializing an object: database/object.md
         - Splayed tables: kb/splayed-tables.md
         - Partitioned tables: kb/partition.md
         - Segmented databases: database/segment.md
-        - Multiple partitions (WP): wp/multi-partitioned-dbs/index.md
+        - Multiple partitions: wp/multi-partitioned-dbs/index.md
       - Maintenance:
-        - Data management (WP): wp/data-management.md
+        - Data management: wp/data-management.md
         - Data-At-Rest Encryption: kb/dare.md
         - File compression: kb/file-compression.md
-        - Compression (WP): wp/compress/index.md
-        - Permissions (WP): wp/permissions/index.md
-        - Query optimization (WP): wp/columnar-database/index.md
-        - Query scaling (WP): wp/query-scaling.md
-        - Time-series simplification (WP): wp/ts-shrink/index.md
+        - Compression: wp/compress/index.md
+        - Permissions: wp/permissions/index.md
+        - Query optimization: wp/columnar-database/index.md
+        - Query scaling: wp/query-scaling.md
+        - Time-series simplification: wp/ts-shrink/index.md
         - Compacting HDB sym: kb/compacting-hdb-sym.md
-        - Working with sym files (WP): wp/symfiles.md
+        - Working with sym files: wp/symfiles.md
     - Developing:
       - IPC:
         - Overview: basics/ipc.md
@@ -460,7 +460,7 @@ nav:
         - Named pipes: kb/named-pipes.md
         - Serialization examples: kb/serialization.md
         - Server calling client: kb/server-calling-client.md
-        - Socket sharding (WP): wp/socket-sharding/index.md
+        - Socket sharding: wp/socket-sharding/index.md
         - SSL/TLS: kb/ssl.md
         - HTTP: kb/http.md
         - WebSockets: kb/websockets.md
@@ -474,7 +474,7 @@ nav:
         - Unit tests: kb/unit-tests.md
         - Monitor & control execution: kb/using-dotz.md
       - Coding:
-        - Data visualization (WP): wp/data-visualization/index.md
+        - Data visualization: wp/data-visualization/index.md
         - Geospatial indexing: kb/geospatial.md
         - Linear programming: kb/lp.md
         - Multithreaded input: kb/multithreaded-input.md
@@ -494,13 +494,13 @@ nav:
         - inetd, xinetd: kb/inetd.md
         - Linux production notes: kb/linux-production.md
         - Logging: kb/logging.md
-        - Multi-threading (WP): wp/multi-thread/index.md
+        - Multi-threading: wp/multi-thread/index.md
         - Multiple versions: kb/versions.md
         - Parallel processing: basics/peach.md
         - Performance tips: kb/performance-tips.md
         - Replay logfile: kb/replay-log.md
         - Shebang script: develop/shebang.md
-        - Surveillance latency (WP): wp/surveillance-latency/index.md
+        - Surveillance latency: wp/surveillance-latency/index.md
         - Windows service: kb/windows-service/index.md
       - Release notes:
         - History: releases/index.md
@@ -528,31 +528,31 @@ nav:
       - Alternative in-memory layouts: kb/alternative-in-memory-layouts.md
       - Chained tickerplant: kb/chained-tickerplant.md
       - Corporate actions: kb/corporate-actions.md
-      - Data recovery for kdb+tick (WP): wp/data-recovery.md
-      - Disaster recovery (WP): wp/disaster-recovery/index.md
-      - Gateway design (WP): wp/gateway-design/index.md
+      - Data recovery for kdb+tick: wp/data-recovery.md
+      - Disaster recovery: wp/disaster-recovery/index.md
+      - Gateway design: wp/gateway-design/index.md
       - kdb+tick configuration: kb/kdb-tick.md
-      - kdb+tick profiling (WP): wp/tick-profiling.md
+      - kdb+tick profiling: wp/tick-profiling.md
       - Kubernetes: 'https://youtu.be/jqtkkCqBvr4'
       - Load balancing: kb/load-balancing.md
       - Memory backed by files: basics/memory-backed.md
       - Optane Memory:
         - Optane Memory and kdb+: kb/optane.md
         - Performance tests: architecture/optane-tests.md
-      - Order Book (WP): wp/order-book.md
+      - Order Book: wp/order-book.md
       - Publish and subscribe: kb/publish-subscribe.md
-      - Query Routing (WP): wp/query-routing/index.md
-      - Real-time tick subscribers (WP): wp/rt-tick/index.md
+      - Query Routing: wp/query-routing/index.md
+      - Real-time tick subscribers: wp/rt-tick/index.md
       - Write-only RDB: kb/w-q.md
       - Advanced:
-        - Distributed systems (WP): wp/query-interface.md
-        - Intraday writedown (WP): wp/intraday-writedown/index.md
+        - Distributed systems: wp/query-interface.md
+        - Intraday writedown: wp/intraday-writedown/index.md
     - Interfaces:
       - Languages:
         - C/C++:
           - Quick guide: interfaces/c-client-for-q.md
           - API reference: interfaces/capiref.md
-          - C API for kdb+ (WP): wp/capi/index.md
+          - C API for kdb+: wp/capi/index.md
           - Using C/C++ functions: interfaces/using-c-functions.md
         - C#: interfaces/csharp.md
         - Foreign Function Interface (FFI): interfaces/ffi.md
@@ -564,14 +564,14 @@ nav:
       - KX libraries: interfaces/index.md
       - Bloomberg: interfaces/q-client-for-bloomberg.md
       - Excel: interfaces/excel-client-for-q.md
-      - FIX messaging (WP): wp/fix-messaging.md
+      - FIX messaging: wp/fix-messaging.md
       - GPUs: interfaces/gpus.md
-      - Lightning tickerplants (WP): wp/lightning-tickerplants/index.md
+      - Lightning tickerplants: wp/lightning-tickerplants/index.md
       - Matlab: interfaces/matlab-client-for-q.md
       - ODBC: interfaces/q-client-for-odbc.md
       - ODBC3: interfaces/q-server-for-odbc3.md
     #  - ODBC/Simba: interfaces/odbc-simba.md
-      - Pub/sub with Solace (WP): wp/solace/index.md
+      - Pub/sub with Solace: wp/solace/index.md
       - Open source: github.md
       - Machine learning: ml.md
     - Using kdb+ in the cloud:
@@ -595,12 +595,12 @@ nav:
         #- Marketplace: cloud/gcpm/index.md
         - Reference architecture: cloud/gcpm/architecture.md
         #- License: license/gcp.md
-      - Auto Scaling (WP):
+      - Auto Scaling:
         - About: cloud/autoscale/index.md
         - Amazon Web Services: cloud/autoscale/aws.md
         - Realtime data cluster: cloud/autoscale/rdc.md
         - Costs and risks: cloud/autoscale/cost-risk.md
-      - Surveillance in the Cloud (WP): wp/surv-cloud/index.md
+      - Surveillance in the Cloud: wp/surv-cloud/index.md
       - Other file systems:
           - MapR-FS: cloud/otherfs/mapr.md
           - Goofys: cloud/otherfs/goofys.md


### PR DESCRIPTION
left were 2 pages named as white paper version & non-white paper (e.g. web sockets)...will be merged into 1 doc
page that lists all white papers left for the moment
