### PR TITLE
refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 Documentation for kdb+ and q
 ============================
 
-
-
-Version 2.0 of the documentation site at [code.kx.com/q](https://code.kx.com/q).
-
-
+Source for [code.kx.com/q](https://code.kx.com/q).
 
 Platform
 --------
@@ -13,19 +9,4 @@ Platform
 This site is generated with the [MkDocs](https://mkdocs.org/) static-site generator, with the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme. 
 
 See [`install.md`](CONTRIBUTING/install.md) for how to compile the site. 
-
-
-Not upwardly compatible
------------------------
-
-Version 2.0 substantially reorganizes the URL structure of the site. 
-Most keywords and operators now have short URLs, e.g. code.kx.com/q/ref/aj and code.kx.com/q/ref/fill. 
-
-This marks a break from [Version 1.0](https://github.com/kxsystems/docs-v1/). 
-There is no Git continuity between the two repos. 
-
-The terminology revision begun in Version 1.0 is complete: _adverbs_ are now _iterators_. The Reference material for them has been completely rewritten and the 2013 whitepaper “Efficient use of adverbs” re-issued as [“Iterators”](https://code.kx.com/q/wp/iterators/). The concept of _rank_ is extended from functions to all applicable values. _Variadic_ replaces _ambivalent_ for values (e.g. derived functions and matrixes) that may be applied as either unary or binary. 
-
-The Cookbook articles are now in the [Knowledge Base](https://code.kx.com/q/kb/).
-
 

--- a/docs/basics/errors.md
+++ b/docs/basics/errors.md
@@ -620,7 +620,7 @@ On launch
 
 error | explanation
 ------|------------
-{timestamp} couldn't connect to license daemon | Could not connect to KX license server ([kdb+ On Demand](../learn/licensing.md#licensing-server-for-kdb-on-demand))
+{timestamp} couldn't connect to license daemon | Could not connect to KX license server ([kdb+ On Demand](../learn/licensing.md#licensing-server))
 [](){#cores}cores | The license is for [fewer cores than available](../learn/licensing.md#core-restrictions)
 [](){#cpu}cpu | The license is for fewer CPUs than available
 [](){#exp}exp | License expiry date is prior to system date

--- a/docs/interfaces/q-server-for-odbc3.md
+++ b/docs/interfaces/q-server-for-odbc3.md
@@ -19,8 +19,30 @@ Requirements: V3.2 or later.
 
 :fontawesome-regular-map: [**Data visualization with kdb+ using ODBC**: a Tableau case study](../wp/data-visualization/index.md "White paper")
 
+## kdb+ configuration
 
-## Installation
+The kdb+ process should be [listening on port](../basics/listening-port.md) which relates to the port choosen and defined in the odbc configuration.
+
+Unzip qodbc3.zip, and copy `ps.k` to `$QHOME`. Ensure you have `ps.k` loaded into the kdb+ process:
+
+```q
+q)\l ps.k
+```
+
+Run `.s.ver` to check that ps.k has been loaded and for the current version e.g.
+```q
+q).s.ver
+1.15
+```
+
+The following is an example of staring kdb+ with ps.k listening on port 5000
+
+```bash
+q ps.k -p 5000
+```
+
+
+## ODBC DSN configuration
 
 Software that uses ODBC connections refer to individual connections via a `DSN`(Data Source Name). 
 The DSN details the ODBC driver (e.g. qodbc3) and connection details specific to the data source (e.g. hostname, username, etc).
@@ -29,13 +51,57 @@ The following details adding a new DSN to connect to kdb+:
 
 ### Windows
 
+#### Administrator 
+
+The following details installing the ODBC driver and configuring a user or system DSN as an administrator.
+
 1.  Close Tableau or anything that uses ODBC
 2.  Extract qodbc3.zip to temporary location. Go to the directory corresponding to your OS architecture (w64 or w32)
 3.  Run `d0.exe` as Administrator. This will copy `qodbc3.dll` to the correct location – you don’t need to do that yourself.
 4.  You will now be able to add new kdb+ DSNs (data sources) in the `ODBC Data Source Administrator (64-bit)` (or `32-bit` if on 32-bit OS). Make sure to select `kdb+(odbc3)` in the list of drivers. You will be prompted for DSN name, hostname, port, username and password.
-5.  In the ODBC data source administrator, click _Start Tracing_ on the _Tracing_ tab.
-6.  Copy `q.tdc` to My Documents\My Tableau Repository\Datasources
-7.  Copy `ps.k` to `$QHOME`
+5.  Use `Test Connection` within the DSN configuration screen to check that the connection to kdb+ is working.
+
+#### Non-administator
+
+This is an alternative to the Administrator instructions above.
+
+It is possible to add a DSN without administrator access, and might be useful for some users. 
+This defines the DSN connection details in a Registry file rather than adding new DSNs directly in the ODBC Data Source Administrator. 
+This is an alternative to steps 3, 4 and 5 in the instructions linked to [above](#administrator).
+
+Create a registry file (for example `kdb_odbc.reg`) using a text editor (for example `notepad`). An example of the file contents are below:
+
+```txt
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\SOFTWARE\ODBC\ODBC.INI\DEV]
+"Driver"="C:\\Users\\Developer\\Desktop\\qodbc3\\w64\\qodbc3.dll"
+"Description"="KDB ODBC3 Driver"
+"HOST"="localhost:5000"
+"LRGMSGS"="1"
+"PWD"="password"
+"QODBC3AUTH"="0"
+"TLS"="0"
+"UID"="username"
+[HKEY_CURRENT_USER\SOFTWARE\ODBC\ODBC.INI\ODBC Data Sources]
+"DEV"="KDB ODBC3 Driver"
+```
+
+_The contents should be customised to your installation._
+Note that the `HKEY_CURRENT_USER\SOFTWARE\ODBC\ODBC.INI\DEV` creates a user DSN called `DEV`. 
+This can be altered to produce a unique DSN name for each system. Ensure that the driver value is changed to the location at which the `qodbc3.dll` file resides, and that the 
+`HOST`/`PWD`/`UID` are set to values for you install.
+
+Running the Registry File will create a new user DSN. This can be verified by opening the Windows `ODBC Data Source Administrator`. If Windows reports that
+`The driver of this User DSN does not exist`, this can be expected as the driver has not been registered by an administrator within the `Driver` tab.
+
+#### Tableau configuration
+
+To use with Tableau, copy `q.tdc` to the appropriate directory for your application as detailed [here](https://help.tableau.com/current/pro/desktop/en-us/connect_customize.htm#installing-tdc-and-properties-files). 
+
+The `q.tdc` file is a `Tableau Datasource Customization` (TDC) file to customize Tableau-specific settings for the kdb+ ODBC connection.
+
+!!! note "The destination directory can be different depending on whether Tableau Desktop or Tableau Server is being used"
 
 ### Linux
 
@@ -65,18 +131,7 @@ You should now be able to connect to your DSN with `isql`:
 $ isql -3 -v -k 'DSN=your_dsn_name;'
 ```
 
-## Running
-
-Ensure you have `ps.k` loaded into the kdb+ process specified in your DSN:
-
-```q
-q)\l ps.k
-```
-
-The kdb+ process should also be [listening on port](../basics/listening-port.md) which relates to the port choosen and defined in the odbc configuration.
-
-
-## Notes
+## Tableau Notes
 
 To use q from Tableau’s Custom SQL use the `q()` function, e.g.:
 
@@ -99,4 +154,41 @@ The driver translates SQL expressions into q and inherits q’s data model. This
 4.  `COUNT` and `COUNT DISTINCT` don’t ignore nulls
 
 Also, SQL selects from partitioned tables are not supported – one should pre-select from a partitioned table using the `q()` function instead.
+
+## Debugging
+
+ODBC implementations provide a tracing capability to log interactions with an ODBC driver. This can aid in diagnosing any issues. Tracing can have a detremental 
+effect to ODBC performance.
+
+### Windows
+
+In the ODBC data source administrator, click _Start Tracing_ on the _Tracing_ tab. Please ensure tracing is disabled after debugging complete.
+
+An example of the data recorded to the `SQL.LOG`:
+
+```txt
+powershell      da8-9a0	ENTER SQLExecDirectW
+		        HSTMT               0x00000256C37A6920
+                WCHAR *             0x00000256AA98112C [      -3] "SELECT * FROM t\ 0"
+                SDWORD                    -3
+...
+powershell      da8-9a0	EXIT  SQLGetData  with return code 0 (SQL_SUCCESS)
+		        HSTMT               0x00000256C37A6920
+		        UWORD                        2
+		        SWORD                       -8 <SQL_C_WCHAR>
+		        PTR                 0x00000256A79BB1D0 [       2] "1"
+		        SQLLEN                  4092
+		        SQLLEN *            0x000000DAA198E160 (2)
+```
+
+### Linux
+
+Set the `Trace` and `TraceFile` keyword/value pairs in the [ODBC] section of the odbc.ini file, for example
+
+```txt
+TraceFile  = /tmp/odbc.trace
+Trace      = 1
+```
+
+Please ensure tracing is disabled after debugging complete.
 

--- a/docs/interfaces/q-server-for-odbc3.md
+++ b/docs/interfaces/q-server-for-odbc3.md
@@ -167,7 +167,7 @@ This is a feature of the ODBC system, and not a feature unique to the kdb+ drive
 
 In the ODBC data source administrator, click _Start Tracing_ on the _Tracing_ tab. 
 
-An example of the data recorded to the `SQL.LOG`:
+See below an example of the data recorded to the `SQL.LOG`:
 
 ```txt
 powershell      da8-9a0	ENTER SQLExecDirectW

--- a/docs/interfaces/q-server-for-odbc3.md
+++ b/docs/interfaces/q-server-for-odbc3.md
@@ -141,9 +141,6 @@ To use q from Tableau’s Custom SQL use the `q()` function, e.g.:
 
 Parameters can be supplied by Tableau. Note that Tableau’s _string_ type corresponds to q’s symbol and _datetime_ corresponds to timestamp.
 
-`test.q` provides additional examples of SQL usage, including the create/insert/update/delete statement syntax.
-
-
 ## Compatibility
 
 The driver translates SQL expressions into q and inherits q’s data model. This gives rise to the following SQL compatibility issues:
@@ -154,6 +151,8 @@ The driver translates SQL expressions into q and inherits q’s data model. This
 4.  `COUNT` and `COUNT DISTINCT` don’t ignore nulls
 
 Also, SQL selects from partitioned tables are not supported – one should pre-select from a partitioned table using the `q()` function instead.
+
+`test.q` provides additional examples of SQL usage, including the create/insert/update/delete statement syntax.
 
 ## Debugging
 

--- a/docs/interfaces/q-server-for-odbc3.md
+++ b/docs/interfaces/q-server-for-odbc3.md
@@ -85,7 +85,7 @@ SQLLEN Size........: 8
 SQLSETPOSIROW Size.: 8
 ```
 
-Add the driver to your list of drivers by editing the driver ini file ( `/etc/odbcinst.ini`). An example of the definition follows (note: the driver locaton should be altered to the location choosen on your system):
+Add the driver to your list of drivers by editing the driver `ini` file ( `/etc/odbcinst.ini`). An example of the definition follows (note: the driver location should be altered to the location chosen on your system):
 
 ```ini
 [kdb+(odbc3)]

--- a/docs/interfaces/q-server-for-odbc3.md
+++ b/docs/interfaces/q-server-for-odbc3.md
@@ -5,7 +5,6 @@ description: The ODBC3 server allows applications to query kdb+ via the ODBC int
 # :fontawesome-solid-database: kdb+ server for ODBC3
 
 
-
 The ODBC3 driver allows applications to query kdb+ via the ODBC interface.  
 :fontawesome-brands-github: [KxSystems/kdb/c/qodbc3.zip](https://github.com/KxSystems/kdb/blob/master/c/qodbc3.zip)
 
@@ -19,7 +18,9 @@ Requirements: V3.2 or later.
 
 :fontawesome-regular-map: [**Data visualization with kdb+ using ODBC**: a Tableau case study](../wp/data-visualization/index.md "White paper")
 
-## kdb+ configuration
+## Installation
+
+### kdb+ configuration
 
 The kdb+ process should be [listening on port](../basics/listening-port.md) which relates to the port choosen and defined in the odbc configuration.
 
@@ -41,17 +42,14 @@ The following is an example of staring kdb+ with ps.k listening on port 5000
 q ps.k -p 5000
 ```
 
-
-## ODBC DSN configuration
+### ODBC DSN configuration
 
 Software that uses ODBC connections refer to individual connections via a `DSN`(Data Source Name). 
 The DSN details the ODBC driver (e.g. qodbc3) and connection details specific to the data source (e.g. hostname, username, etc).
 
 The following details adding a new DSN to connect to kdb+:
 
-### Windows
-
-#### Administrator 
+#### Windows
 
 The following details installing the ODBC driver and configuring a user or system DSN as an administrator.
 
@@ -61,49 +59,7 @@ The following details installing the ODBC driver and configuring a user or syste
 4.  You will now be able to add new kdb+ DSNs (data sources) in the `ODBC Data Source Administrator (64-bit)` (or `32-bit` if on 32-bit OS). Make sure to select `kdb+(odbc3)` in the list of drivers. You will be prompted for DSN name, hostname, port, username and password.
 5.  Use `Test Connection` within the DSN configuration screen to check that the connection to kdb+ is working.
 
-#### Non-administator
-
-This is an alternative to the Administrator instructions above.
-
-It is possible to add a DSN without administrator access, and might be useful for some users. 
-This defines the DSN connection details in a Registry file rather than adding new DSNs directly in the ODBC Data Source Administrator. 
-This is an alternative to steps 3, 4 and 5 in the instructions linked to [above](#administrator).
-
-Create a registry file (for example `kdb_odbc.reg`) using a text editor (for example `notepad`). An example of the file contents are below:
-
-```txt
-Windows Registry Editor Version 5.00
-
-[HKEY_CURRENT_USER\SOFTWARE\ODBC\ODBC.INI\DEV]
-"Driver"="C:\\Users\\Developer\\Desktop\\qodbc3\\w64\\qodbc3.dll"
-"Description"="KDB ODBC3 Driver"
-"HOST"="localhost:5000"
-"LRGMSGS"="1"
-"PWD"="password"
-"QODBC3AUTH"="0"
-"TLS"="0"
-"UID"="username"
-[HKEY_CURRENT_USER\SOFTWARE\ODBC\ODBC.INI\ODBC Data Sources]
-"DEV"="KDB ODBC3 Driver"
-```
-
-_The contents should be customised to your installation._
-Note that the `HKEY_CURRENT_USER\SOFTWARE\ODBC\ODBC.INI\DEV` creates a user DSN called `DEV`. 
-This can be altered to produce a unique DSN name for each system. Ensure that the driver value is changed to the location at which the `qodbc3.dll` file resides, and that the 
-`HOST`/`PWD`/`UID` are set to values for you install.
-
-Running the Registry File will create a new user DSN. This can be verified by opening the Windows `ODBC Data Source Administrator`. If Windows reports that
-`The driver of this User DSN does not exist`, this can be expected as the driver has not been registered by an administrator within the `Driver` tab.
-
-#### Tableau configuration
-
-To use with Tableau, copy `q.tdc` to the appropriate directory for your application as detailed [here](https://help.tableau.com/current/pro/desktop/en-us/connect_customize.htm#installing-tdc-and-properties-files). 
-
-The `q.tdc` file is a `Tableau Datasource Customization` (TDC) file to customize Tableau-specific settings for the kdb+ ODBC connection.
-
-!!! note "The destination directory can be different depending on whether Tableau Desktop or Tableau Server is being used"
-
-### Linux
+#### Linux
 
 Requirements: [unixODBC](http://www.unixodbc.org) 2.3.4, [Binutils](https://www.gnu.org/software/binutils/) (ld)
 
@@ -130,6 +86,14 @@ You should now be able to connect to your DSN with `isql`:
 ```bash
 $ isql -3 -v -k 'DSN=your_dsn_name;'
 ```
+
+### Tableau configuration
+
+If there is a requirement to connect Tableau with kdb+, copy `q.tdc` to the appropriate directory for your application as detailed [here](https://help.tableau.com/current/pro/desktop/en-us/connect_customize.htm#installing-tdc-and-properties-files). 
+
+The `q.tdc` file is a `Tableau Datasource Customization` (TDC) file to customize Tableau-specific settings for the kdb+ ODBC connection.
+
+!!! note "The destination directory can be different depending on whether Tableau Desktop or Tableau Server is being used"
 
 ## Tableau Notes
 

--- a/docs/interfaces/q-server-for-odbc3.md
+++ b/docs/interfaces/q-server-for-odbc3.md
@@ -44,7 +44,7 @@ q ps.k -p 5000
 
 ### ODBC driver and DSN configuration
 
-Software that uses ODBC connections refer to individual connections via a `DSN`(Data Source Name). 
+Software that uses ODBC connections refer to individual connections using a `DSN`(Data Source Name). 
 The DSN details the ODBC driver (e.g. qodbc3) and connection details specific to the data source (e.g. hostname, username, etc).
 
 The following details adding a new DSN to connect to kdb+:

--- a/docs/interfaces/q-server-for-odbc3.md
+++ b/docs/interfaces/q-server-for-odbc3.md
@@ -159,7 +159,7 @@ Also, SQL selects from partitioned tables are not supported – one should pre-s
 ODBC implementations provide a tracing capability to log interactions with an ODBC driver. This can aid in diagnosing any issues. Tracing can have a detremental 
 effect to ODBC performance.
 
-This is a feature of the ODBC system, and not a feature unique to the kdb+ driver. Associated documentation, features and troubleshooting can be found online for your OS.
+This is a feature of the ODBC system, and not a feature unique to the kdb+ driver. Associated documentation, features, and troubleshooting can be found online for your OS.
 
 !!! warn "Connection details can be logged, therefore the log file should be stored in a private location"
 

--- a/docs/interfaces/q-server-for-odbc3.md
+++ b/docs/interfaces/q-server-for-odbc3.md
@@ -36,7 +36,7 @@ q).s.ver
 1.15
 ```
 
-The following is an example of staring kdb+ with ps.k listening on port 5000
+The following is an example of starting kdb+ with ps.k listening on port 5000
 
 ```bash
 q ps.k -p 5000

--- a/docs/interfaces/q-server-for-odbc3.md
+++ b/docs/interfaces/q-server-for-odbc3.md
@@ -5,7 +5,7 @@ description: The ODBC3 server allows applications to query kdb+ via the ODBC int
 # :fontawesome-solid-database: kdb+ server for ODBC3
 
 
-The ODBC3 driver allows applications to query kdb+ via the ODBC interface.  
+The ODBC3 driver allows applications to query kdb+ through the ODBC interface.  
 :fontawesome-brands-github: [KxSystems/kdb/c/qodbc3.zip](https://github.com/KxSystems/kdb/blob/master/c/qodbc3.zip)
 
 Currently the applications may run on the following platforms: w64, w32, l64, l32. Primary compatibility target has been [Tableau](https://www.tableau.com/), although other uses are welcome.

--- a/docs/interfaces/q-server-for-odbc3.md
+++ b/docs/interfaces/q-server-for-odbc3.md
@@ -6,7 +6,7 @@ description: The ODBC3 server allows applications to query kdb+ via the ODBC int
 
 
 
-The ODBC3 server allows applications to query kdb+ via the ODBC interface.  
+The ODBC3 driver allows applications to query kdb+ via the ODBC interface.  
 :fontawesome-brands-github: [KxSystems/kdb/c/qodbc3.zip](https://github.com/KxSystems/kdb/blob/master/c/qodbc3.zip)
 
 Currently the applications may run on the following platforms: w64, w32, l64, l32. Primary compatibility target has been [Tableau](https://www.tableau.com/), although other uses are welcome.
@@ -22,6 +22,11 @@ Requirements: V3.2 or later.
 
 ## Installation
 
+Software that uses ODBC connections refer to individual connections via a `DSN`(Data Source Name). 
+The DSN details the ODBC driver (e.g. qodbc3) and connection details specific to the data source (e.g. hostname, username, etc).
+
+The following details adding a new DSN to connect to kdb+:
+
 ### Windows
 
 1.  Close Tableau or anything that uses ODBC
@@ -31,7 +36,6 @@ Requirements: V3.2 or later.
 5.  In the ODBC data source administrator, click _Start Tracing_ on the _Tracing_ tab.
 6.  Copy `q.tdc` to My Documents\My Tableau Repository\Datasources
 7.  Copy `ps.k` to `$QHOME`
-
 
 ### Linux
 
@@ -60,7 +64,6 @@ You should now be able to connect to your DSN with `isql`:
 ```bash
 $ isql -3 -v -k 'DSN=your_dsn_name;'
 ```
-
 
 ## Running
 

--- a/docs/interfaces/q-server-for-odbc3.md
+++ b/docs/interfaces/q-server-for-odbc3.md
@@ -188,7 +188,7 @@ Please ensure tracing is disabled after debugging complete.
 
 ### Linux
 
-In the `[ODBC]` section of the driver ini file (`/etc/odbcinst.ini`), set `Trace` to `1` to enable tracing and `TraceFile` to the location of the log file to create. 
+In the `[ODBC]` section of the driver `ini` file (`/etc/odbcinst.ini`), set `Trace` to `1` to enable tracing and `TraceFile` to the location of the log file to create. 
 Additional configuration options are available. For example:
 
 ```txt

--- a/docs/learn/licensing.md
+++ b/docs/learn/licensing.md
@@ -17,29 +17,6 @@ Everyone. All use of kdb+ is governed by a license.
 
 <!-- :fontawesome-regular-hand-point-right: [Licenses](https://kx.com/connect-with-us/licenses/) at kx.com -->
 
-
-=== "Non-commercial use"
-
-    Free 64-bit kdb+ On-Demand Personal Edition is for personal, non-commercial use. 
-    Currently, it may be used on up to 2 computers, and up to a maximum of 16 cores per computer, but is not licensed for use on any cloud – only on personal computers. 
-    It may not be used for any commercial purposes.
-    See the [full terms and conditions](https://kx.com/download-kdb/). 
-
-    It requires a `kc.lic` license key file and an always-on internet connection to operate.
-
-
-=== "Commercial use"
-
-    Use of commercial kdb+ is covered by your license agreement with KX.
-
-    Your copy of kdb+ will need access to a valid license key file.
-
-    If you wish to begin using kdb+ commercially, please contact sales@kx.com.
-
-
-## License key files
-
-All 64-bit versions of kdb+ need a valid license key file to run.
 Without one, kdb+ signals an [error](../basics/errors.md#license-errors) `'k4.lic` and aborts.
 
 ```txt
@@ -56,13 +33,35 @@ If both are found, the `kc.lic` file is used.
 
 ## Obtain a license key file
 
+A license file can be a commercial license or an on-demand person license (for non-commercial use).
+
 ### On-Demand
 
-Follow the [download instructions](https://kx.com/kdb-personal-edition-download/) to get your kc.lic.
+Free 64-bit kdb+ On-Demand Personal Edition is for personal, non-commercial use.
+Currently, it may be used on up to 2 computers, and up to a maximum of 16 cores per computer, but is not licensed for use on any cloud – only on personal computers.
+It may not be used for any commercial purposes.
+See the [full terms and conditions](https://kx.com/download-kdb/). Follow the [download instructions](https://kx.com/kdb-personal-edition-download/) to get your kc.lic.
+
+It requires a `kc.lic` license key file and an always-on internet connection to operate.
+
+#### Licensing server
+
+If kdb+ with an on-demand license cannot contact the KX license server it will abort with a timestamped message.
+
+```q
+'2018.03.28T11:20:03.831 couldn't connect to license daemon -- exiting
+```
+
+If an HTTP proxy is required, the environment variables `http_proxy` or `HTTP_PROXY` define the URL of the HTTP proxy to use.
+Since 4.1t 2022.11.01,4.0 2022.10.26,4.0ce 2022.09.16 the on-demand system honours the NO_PROXY/no_proxy environment variables, with the lowercase version taking precedence.
 
 ### Commercial
 
-To begin using kdb+ commercially, contact sales@kx.com.
+Use of commercial kdb+ is covered by your license agreement with KX.
+
+Your copy of kdb+ will need access to a valid license key file.
+
+If you wish to begin using kdb+ commercially, please contact sales@kx.com.
 
 ## Install the license key file
 
@@ -88,7 +87,7 @@ If you are sharing use of a commercial license, you will probably want to set th
 A list of possible errors can be found [here](../basics/errors.md#license-errors).
 
 
-## Keeping the license key file elsewhere
+### Keeping the license key file elsewhere
 
 The default location for the license key file is the `QHOME` folder. You do not have to keep the license key file there. You can use the environment variable `QLIC` to specify a different filepath.
 
@@ -99,22 +98,6 @@ The default location for the license key file is the `QHOME` folder. You do not 
     ```bash
     QLIC='/Users/simon/q'
     ```
-
-
-## Licensing server for kdb+ On Demand
-
-As well as a license key file, kdb+ On Demand also requires frequent contact with the KX licensing server. 
-For this you need an always-on Net connection.
-
-If kdb+ cannot contact the KX server it will abort with a timestamped message.
-
-```q
-'2018.03.28T11:20:03.831 couldn't connect to license daemon -- exiting
-```
-
-If an HTTP proxy is required, the environment variables `http_proxy` or `HTTP_PROXY` define the URL of the HTTP proxy to use.
-Since 4.1t 2022.11.01,4.0 2022.10.26,4.0ce 2022.09.16 the on-demand system honours the NO_PROXY/no_proxy environment variables, with the lowercase version taking precedence.
-
 
 ## Core restrictions
 
@@ -149,7 +132,6 @@ The number of licensed cores is always 16 for the on-demand license.
     ```bash
     scutil --set HostName "mymbp.local"
     ```
-
 
 ## License questions
 

--- a/docs/wp/data-visualization/index.md
+++ b/docs/wp/data-visualization/index.md
@@ -507,9 +507,9 @@ within the workbook itself. Take the following scenario:
 -   The workbook must be reopened, and the DSN details changed to the production DSN, before final promotion to `Production`.
 
 This process is manual and prone to errors. For kdb+
-connections, it is recommended to use the `tabcmd` command-line utility
-which, among other things, enables the user to publish to Tableau Server
-from the command line. This utility allows the user to deploy sheets
+connections, it is recommended to use the [`tabcmd`](https://help.tableau.com/current/server/en-us/tabcmd.htm) command-line utility
+which, among other things, enables the user to [publish to Tableau Server
+from the command line](https://help.tableau.com/current/server/en-us/tabcmd_cmd.htm#iddf805b62-18ff-4497-9245-adc6905b2084). This utility allows the user to deploy sheets
 programmatically, streamlining the process hugely. It also means that as
 part of the deploy procedure, the workbook can be edited by a script
 before publishing via `tabcmd`. This means you can do some efficient

--- a/docs/wp/data-visualization/index.md
+++ b/docs/wp/data-visualization/index.md
@@ -49,49 +49,11 @@ All tests were run using kdb+ version 3.5 and Tableau 10.3.
 ## Connecting to kdb+ using ODBC
 
 Instructions on how to connect kdb+ from Tableau Desktop for both
-Windows and Linux can be found at [Interfaces: kdb+ server for ODBC3](../../interfaces/q-server-for-odbc3.md).
+Windows and Linux can be found at [Interfaces: kdb+ server for ODBC3](../../interfaces/q-server-for-odbc3.md), ensuring that the [extra step](../../interfaces/q-server-for-odbc3.md#tableau-configuration) is performed for Tableau.
 
 For an ODBC driver to connect to an application, it needs a DSN
 (Data Source Name). 
 A DSN contains the name, directory and driver of the database, and (depending on the type of DSN) the access credentials of the user.
-
-With administrator rights, [adding a new DSN](../../interfaces/q-server-for-odbc3.md) is relatively
-straightforward. 
-
-A second way to add a
-DSN does not require administrator access, and might be useful
-for some users. This defines the DSN connection
-details in a Registry file rather than adding new DSNs directly in the
-ODBC Data Source Administrator. This is an alternative to steps
-3, 4 and 5 in the instructions linked to above.
-
-1.  Copy `qodbc3.dll` to the correct location.
-
-2.  Define the Registry file and save it to `C:\Users\<username>` with
-    a `.reg` extension. Here is an example of what the file might look
-    like.
-
-    ```txt
-    Windows Registry Editor Version 5.00
-    [HKEY_CURRENT_USER\SOFTWARE\ODBC\ODBC.INI\DEV]
-    "Driver"="P:\…\qodbc3\w64\qodbc3.dll"
-    "Description"="KDB ODBC3 Driver"
-    "HOST"="hostname:port"
-    "UID"="username"
-    "PWD"="password"
-    [HKEY_CURRENT_USER\SOFTWARE\ODBC\ODBC.INI\ODBC Data Sources]
-    "DEV"="KDB ODBC3 Driver"
-    ```
-
-3.  Double-click on the file when saved. This will create the correct
-    driver entries, which for this example will be a new kdb+ DSN called
-    `DEV`.
-
-This second method makes it easier to
-maintain and share connection details with multiple users, as the DSN
-details reside in a separate text file rather than in the Windows
-Registry.
-
 
 ### Connecting to kdb+ from Tableau Desktop
 

--- a/docs/wp/data-visualization/index.md
+++ b/docs/wp/data-visualization/index.md
@@ -213,7 +213,7 @@ _Dynamic Parameters_.
 
 As mentioned above in _Simple parameters_, Tableau
 parameters are limited to static values, and a single select option when
-placed in a view. However, there are a number of ways to make parameters
+placed in a view. However, there are several ways to make parameters
 smarter, and can increase their usability and flexibility. Below, two
 such methods are described. 
 

--- a/docs/wp/data-visualization/index.md
+++ b/docs/wp/data-visualization/index.md
@@ -249,7 +249,7 @@ user wants to see is dependent on an input parameter, and a field needs
 to be adjusted accordingly.
 
 For example, in the user-defined `Calculation1` logic below, the quantity
-field will be divided by a different amount depending on the chosen
+field is divided by a different amount depending on the chosen
 Category value. 
 
 ![](img/image12.png)

--- a/docs/wp/data-visualization/index.md
+++ b/docs/wp/data-visualization/index.md
@@ -469,7 +469,7 @@ This process is manual and prone to errors.
 
 For kdb+
 connections, it is recommended to use the [`tabcmd`](https://help.tableau.com/current/server/en-us/tabcmd.htm) command-line utility
-which, among other things, enables the user to [publish to Tableau Server
+which, among other things, enables you to [publish to Tableau Server
 from the command line](https://help.tableau.com/current/server/en-us/tabcmd_cmd.htm#iddf805b62-18ff-4497-9245-adc6905b2084). This utility allows the user to deploy sheets
 programmatically, streamlining the process hugely. It also means that as
 part of the deploy procedure, the workbook can be edited by a script

--- a/docs/wp/data-visualization/index.md
+++ b/docs/wp/data-visualization/index.md
@@ -67,10 +67,10 @@ database you wish to connect to, select the option _Other Databases
 
 Next, select the correct DSN from the dropdown list and click _Connect_.
 This will automatically populate the Connection Attributes in the bottom
-half of the window using the details defined earlier in the Registry
-file. The final step is to click the _Sign In_ button, which creates a
+half of the window using the DSN details defined previously.
+The final step is to click the _Sign In_ button, which creates a
 connection to the kdb+ process, enabling the database to be queried via
-Tableau’s Custom SQL, as demonstrated in the following section.
+Tableau’s Custom SQL, as demonstrated in the following sections.
 
 
 ### Connecting to kdb+ from Tableau Server
@@ -87,8 +87,7 @@ Tableau workbooks can be shared between both by publishing from Tableau
 Desktop to Tableau Server. This procedure is detailed in the
 section [`Publishing to Tableau Server`](#publishing-from-tableau-desktop-to-tableau-server).
 
-To connect via Tableau Server, the Registry file that was presented in
-the previous section needs to be configured. This process may be handled
+This process may be handled
 by an organization’s support team, depending on the installation setup.
 The driver also needs to be installed, and then the connection can be
 initialized much as for Tableau Desktop.

--- a/docs/wp/data-visualization/index.md
+++ b/docs/wp/data-visualization/index.md
@@ -259,7 +259,7 @@ a _Category_ value of `EQ`.
 
 ![](img/image13.png)
 
-In contrast, when the user selects `CORP` the calculated field will be
+In contrast, when the user selects `CORP` the calculated field is
 divided by 50.
 
 ![](img/image14.png)

--- a/docs/wp/data-visualization/index.md
+++ b/docs/wp/data-visualization/index.md
@@ -93,7 +93,7 @@ details reside in a separate text file rather than in the Windows
 Registry.
 
 
-### Connecting to Tableau Desktop
+### Connecting to kdb+ from Tableau Desktop
 
 Once a kdb+ DSN has been added, and the rest of the set-up instructions
 are followed, you are ready to connect to kdb+ from
@@ -111,7 +111,7 @@ connection to the kdb+ process, enabling the database to be queried via
 Tableau’s Custom SQL, as demonstrated in the following section.
 
 
-### Connecting to Tableau Server
+### Connecting to kdb+ from Tableau Server
 
 The set-up instructions above, both explicit and linked, are
 specifically for a user connecting from Tableau Desktop. This is the
@@ -123,7 +123,7 @@ only Tableau Desktop.
 
 Tableau workbooks can be shared between both by publishing from Tableau
 Desktop to Tableau Server. This procedure is detailed in the
-section _Publishing to Tableau Server_.
+section [`Publishing to Tableau Server`](#publishing-from-tableau-desktop-to-tableau-server).
 
 To connect via Tableau Server, the Registry file that was presented in
 the previous section needs to be configured. This process may be handled
@@ -148,7 +148,7 @@ management, when sharing workbooks between developers or when publishing
 them to Tableau Server, this can become problematic. One workaround
 solution to manage this is to wipe these details from the workbook with
 a script before sharing or publishing workbooks. This concept is
-explored below in _Publishing to Tableau Server_.
+explored below in [`Publishing to Tableau Server`](#publishing-from-tableau-desktop-to-tableau-server).
 
 
 ## Tableau functionality for kdb+
@@ -199,9 +199,9 @@ demonstrated in the next section.
     -   SQL selects from partitioned tables are not supported – one should pre-select from a partitioned table using the `q()` function instead
 
 
-### Datatypes
+### Datatype Mapping
 
-Tableau caters for multiple q datatypes.
+Tableau caters for multiple [q datatypes](../../basics/datatypes.md).
 
 Tableau               | q 
 --------------------- | -------------- 
@@ -221,8 +221,9 @@ _Data_ pane as shown below.
 
 ![](img/image4.png)
 
+### Function Parameters
 
-### Simple parameters
+#### Simple parameters
 
 Tableau parameters provide further flexibility when working with q
 functions. To demonstrate, define a function `func` that selects from
@@ -253,6 +254,61 @@ Tableau parameters are limited to static values, and a single select
 option when placed in a view. However, there are ways to make them more
 dynamic and flexible. This will be explored below in
 _Dynamic Parameters_.
+
+#### Dynamic parameters
+
+As mentioned above in _Simple parameters_, Tableau
+parameters are limited to static values, and a single select option when
+placed in a view. However, there are a number of ways to make parameters
+smarter, and can increase their usability and flexibility. Below, two
+such methods are described. 
+
+
+##### Predefining parameter options in a q function
+
+From the previous example, the input parameter Category is limited to
+single values. This can be made more flexible by
+defining in the function a range of acceptable values.
+In the example below, the
+argument `` `all`` leads to a select with no restriction on `category`.
+
+```q
+func:{[mydate;mycategory]
+  $[mycategory=`all;
+    select from tab where date in mydate;
+    select from tab where date in mydate, category in mycategory]
+  };
+```
+
+Then `all` can be added to the list of predefined values in Tableau’s
+definition of Category:
+
+![](img/image11.png)
+
+
+##### Parameters with calculated fields
+
+Using parameters in conjunction with Tableau’s calculated-field
+functionality can be a convenient and flexible tool in calculations as
+well as graphical representation. This is useful when the output the
+user wants to see is dependent on an input parameter, and a field needs
+to be adjusted accordingly.
+
+For example, in the user-defined `Calculation1` logic below, the quantity
+field will be divided by a different amount depending on the chosen
+Category value. 
+
+![](img/image12.png)
+
+Below is sample output from when the user selects
+a _Category_ value of `EQ`.
+
+![](img/image13.png)
+
+In contrast, when the user selects `CORP` the calculated field will be
+divided by 50.
+
+![](img/image14.png)
 
 
 ### Tableau filters
@@ -358,61 +414,6 @@ number of symbols | time (1st query) | time (2nd query)
 100,000,000       | 1021 ms         | <0ms                         
 
 
-### Dynamic parameters
-
-As mentioned above in _Simple parameters_, Tableau
-parameters are limited to static values, and a single select option when
-placed in a view. However, there are a number of ways to make parameters
-smarter, and can increase their usability and flexibility. Below, two
-such methods are described. 
-
-
-#### Predefining parameter options in a q function
-
-From the previous example, the input parameter Category is limited to
-single values. This can be made more flexible by
-defining in the function a range of acceptable values.
-In the example below, the
-argument `` `all`` leads to a select with no restriction on `category`.
-
-```q
-func:{[mydate;mycategory]
-  $[mycategory=`all;
-    select from tab where date in mydate;
-    select from tab where date in mydate, category in mycategory]
-  };
-```
-
-Then `all` can be added to the list of predefined values in Tableau’s
-definition of Category:
-
-![](img/image11.png)
-
-
-#### Using parameters with calculated fields
-
-Using parameters in conjunction with Tableau’s calculated-field
-functionality can be a convenient and flexible tool in calculations as
-well as graphical representation. This is useful when the output the
-user wants to see is dependent on an input parameter, and a field needs
-to be adjusted accordingly.
-
-For example, in the user-defined `Calculation1` logic below, the quantity
-field will be divided by a different amount depending on the chosen
-Category value. 
-
-![](img/image12.png)
-
-Below is sample output from when the user selects
-a _Category_ value of `EQ`.
-
-![](img/image13.png)
-
-In contrast, when the user selects `CORP` the calculated field will be
-divided by 50.
-
-![](img/image14.png)
-
 
 ### Multiple data sources
 
@@ -439,7 +440,7 @@ they are the same datatype. This can be controlled and edited in
 _Data > Edit Relationships_.
 
 
-#### Actions
+#### Dashboard Actions
 
 Once a dashboard is created, the filters are controlled in _Dashboard >
 Actions_. When setting up actions for kdb+ data sources, it is important
@@ -465,7 +466,7 @@ q) t:([] sym:N?`3;volume:N?10.0)
 ![](img/image16.png)
 
 Step-by-step instructions on how to build the dashboard shown below and
-performance tests can be found in Appendix A.
+performance tests can be found in [`Appendix A`](#appendix-a).
 
 ![](img/image17.png)
 
@@ -486,9 +487,9 @@ Exploiting this feature can be hugely useful when working with kdb+ and
 Tableau where the volume of datasets can be very large.
 
 
-## Publishing to Tableau Server
+## Publishing from Tableau Desktop to Tableau Server
 
-As mentioned above, to share workbooks
+To share workbooks
 between Tableau Desktop and Tableau Server you can publish the former to
 the latter. 
 Tableau provides [detailed documentation and instructions](https://help.tableau.com/current/pro/desktop/en-us/publish_workbooks_howto.htm)
@@ -498,7 +499,9 @@ on the general publishing procedure, which involves publishing from within an al
 
 This is not an ideal way to publish workbooks that are connected to a
 kdb+ database, because connection details are stored
-within the workbook itself. Take the following scenario:
+within the workbook itself. 
+
+Take the following scenario:
 
 -   A workbook has been developed in Tableau Desktop and is ready to share to the `Testing` partition in Tableau Server.
 -   Throughout development, a development DSN has been used. But the workbook needs to be published to a UAT DSN.
@@ -506,7 +509,11 @@ within the workbook itself. Take the following scenario:
 -   The workbook again needs to be promoted, this time to the `Production` partition.
 -   The workbook must be reopened, and the DSN details changed to the production DSN, before final promotion to `Production`.
 
-This process is manual and prone to errors. For kdb+
+This process is manual and prone to errors. 
+
+### Publishing using tabcmd
+
+For kdb+
 connections, it is recommended to use the [`tabcmd`](https://help.tableau.com/current/server/en-us/tabcmd.htm) command-line utility
 which, among other things, enables the user to [publish to Tableau Server
 from the command line](https://help.tableau.com/current/server/en-us/tabcmd_cmd.htm#iddf805b62-18ff-4497-9245-adc6905b2084). This utility allows the user to deploy sheets

--- a/docs/wp/data-visualization/index.md
+++ b/docs/wp/data-visualization/index.md
@@ -151,14 +151,7 @@ Queries can be a simple select statement or can become much more complex
 and flexible using inbuilt parameters supplied by Tableau, which will be
 demonstrated in the next section.
 
-!!! warning "Known SQL compatibility issues"
-
-    -   SQL string literals are trimmed like q symbols
-    -   `MIN()` and `MAX()` don’t work on strings
-    -   q strings and booleans lack nulls, therefore SQL operations on null data resulting in these types ‘erase’ nulls
-    -   `COUNT` and `COUNT DISTINCT` don’t ignore nulls
-    -   SQL selects from partitioned tables are not supported – one should pre-select from a partitioned table using the `q()` function instead
-
+!!! warning "List of [known SQL compatibility issues](../../interfaces/q-server-for-odbc3.md#compatibility)"
 
 ### Datatype Mapping
 

--- a/docs/wp/data-visualization/index.md
+++ b/docs/wp/data-visualization/index.md
@@ -470,7 +470,7 @@ This process is manual and prone to errors.
 For kdb+
 connections, it is recommended to use the [`tabcmd`](https://help.tableau.com/current/server/en-us/tabcmd.htm) command-line utility
 which, among other things, enables you to [publish to Tableau Server
-from the command line](https://help.tableau.com/current/server/en-us/tabcmd_cmd.htm#iddf805b62-18ff-4497-9245-adc6905b2084). This utility allows the user to deploy sheets
+from the command line](https://help.tableau.com/current/server/en-us/tabcmd_cmd.htm#iddf805b62-18ff-4497-9245-adc6905b2084). This utility allows you to deploy sheets
 programmatically, streamlining the process hugely. It also means that as
 part of the deploy procedure, the workbook can be edited by a script
 before publishing via `tabcmd`. This means you can do some efficient

--- a/docs/wp/data-visualization/index.md
+++ b/docs/wp/data-visualization/index.md
@@ -65,7 +65,7 @@ details in a Registry file rather than adding new DSNs directly in the
 ODBC Data Source Administrator. This is an alternative to steps
 3, 4 and 5 in the instructions linked to above.
 
-1.  Copy `qodbc.dll` to the correct location.
+1.  Copy `qodbc3.dll` to the correct location.
 
 2.  Define the Registry file and save it to `C:\Users\<username>` with
     a `.reg` extension. Here is an example of what the file might look

--- a/docs/wp/data-visualization/index.md
+++ b/docs/wp/data-visualization/index.md
@@ -78,19 +78,19 @@ Tableau’s Custom SQL, as demonstrated in the following sections.
 The set-up instructions above, both explicit and linked, are
 specifically for a user connecting from Tableau Desktop. This is the
 local version of Tableau installed on a desktop or laptop. Tableau
-Server, on the other hand, is installed on a Windows server and is
-accessible to users via a browser. Tableau Server brings additional
-collaboration, security and scalability capabilities not available using
-only Tableau Desktop.
+Server, on the other hand, is installed on a server and is
+accessible to users via a browser.
 
 Tableau workbooks can be shared between both by publishing from Tableau
 Desktop to Tableau Server. This procedure is detailed in the
 section [`Publishing to Tableau Server`](#publishing-from-tableau-desktop-to-tableau-server).
 
-This process may be handled
-by an organization’s support team, depending on the installation setup.
+This process may be handled by an organization’s support team, depending on the installation setup.
 The driver also needs to be installed, and then the connection can be
 initialized much as for Tableau Desktop.
+
+Note that Tableau Server can require that the dependent kdb+ configuration file `q.tdc`
+be placed in a [different location than Tableau Desktop](../../interfaces/q-server-for-odbc3.md#tableau-configuration), in addition to restarting Tableau Server and all nodes in use.
 
 
 ### Other considerations

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -562,8 +562,8 @@ nav:
       - GPUs: interfaces/gpus.md
       - Matlab: interfaces/matlab-client-for-q.md
       - ODBC:
-        - ODBC: interfaces/q-client-for-odbc.md
-        - ODBC3: interfaces/q-server-for-odbc3.md
+        - ODBC client: interfaces/q-client-for-odbc.md
+        - ODBC3 server: interfaces/q-server-for-odbc3.md
         - ODBC3 and Tableau: wp/data-visualization/index.md
     #  - ODBC/Simba: interfaces/odbc-simba.md
       - Solace pub/sub: wp/solace/index.md


### PR DESCRIPTION
removed repeating license instructions
details on on-demand and commercial license repeated moved relevent sections into appropriate place (e.g. license server moved under on-demand)