### PR TITLE
improving type cross references

### DIFF
--- a/docs/basics/datatypes.md
+++ b/docs/basics/datatypes.md
@@ -69,6 +69,7 @@ The type is a short int:
 [Cast](../ref/cast.md),
 [Tok](../ref/tok.md),
 [`type`](../ref/type.md),
+[`key`](../ref/key.md#type-of-a-vector),
 [`.Q.ty`](../ref/dotq.md#ty-type) (type)
 <br>
 :fontawesome-solid-book-open:

--- a/docs/ref/dotq.md
+++ b/docs/ref/dotq.md
@@ -1994,7 +1994,7 @@ Since V3.6 2018.05.18.
 .Q.ty x
 ```
 
-Where `x` is a list, returns the type of `x` as a character code:
+Where `x` is a list, returns the [type](../basics/datatypes.md) of `x` as a character code:
 
 -   lower case for a vector
 -   upper case for a list of uniform type

--- a/docs/ref/type.md
+++ b/docs/ref/type.md
@@ -43,6 +43,7 @@ q)type (0|+)                    / composition
 ----
 
 :fontawesome-solid-book:
+[`key`](key.md#type-of-a-vector),
 [.Q.ty](dotq.md#ty-type)
 <br>
 :fontawesome-solid-book-open:


### PR DESCRIPTION
Keyword type and function .Q.ty return number (e.g. 7) and character (e.g. j) representation of a type. The [8th overload of key](https://code.kx.com/q/ref/key/#type-of-a-vector) returns the string representation, e.g., long, which is the most readable/intuitive.