### PR TITLE
DOC-878 - fix rlwap/rlwrap typo on "Installing kdb+" page

### DIFF
--- a/docs/learn/install.md
+++ b/docs/learn/install.md
@@ -270,7 +270,7 @@ Run `rlwrap -v` to check if it's currently installed. If not, install `rlwrap` u
 
 After installation, the q command can be changed to always run with `rlwrap`:
 ```bash
-alias q="rlwap -r q"
+alias q="rlwrap -r q"
 ```
 This can be added to the end of the user's [profile](#step-5-edit-your-profile) to take effect on every session.
 


### PR DESCRIPTION
Jira ticket: https://kxl.atlassian.net/browse/DOC-878

Typo on https://code.kx.com/q/learn/install/#step-5-edit-your-profile
alias q="rlwap -r q"
should be rlwrap