### PR TITLE
Clarify documentation on .Q.chk partition template selection for missing tables

### DIFF
--- a/docs/ref/dotq.md
+++ b/docs/ref/dotq.md
@@ -274,7 +274,7 @@ A projection of [`.Q.Xf`](#xf-create-file): i.e. ``.Q.Xf[`char;]``
 .Q.chk x
 ```
 
-Where `x` is a HDB as a filepath, fills tables missing from partitions using the most recent partition as a template, and reports which partitions (but not which tables) it is fixing.
+Where `x` is a HDB as a filepath, fills tables missing from partitions using the most recent partition containing the table as a template, and reports which partitions (but not which tables) it is fixing.
 
 ```q
 q).Q.chk[`:hdb]


### PR DESCRIPTION
The current documentation for `.Q.chk` can be misleading. It says that the most recent partition is used as the template, but this is not true. The most recent partition may itself be missing tables. 

`.Q.chk` actually uses the most recent partition where a table is available.

For example, say I have the following 3 partitions:

2025.02.27/
    t1
    t2
 
2025.02.26/
    t1
    t3
 
2025.02.25/
    t4
 
After running `.Q.chk`, the following will occur:
    2025.02.27 gets t3 from 2025.02.26 and t4 from 2025.02.25
    2025.02.26 gets t2 from 2025.02.27 and t4 from 2025.02.25
    2025.02.25 gets t1 & t2 from 2025.02.27 and t3 from 2025.02.26