### PR TITLE
removed use of 'file descriptor' term

### DIFF
--- a/docs/ref/read0.md
+++ b/docs/ref/read0.md
@@ -6,14 +6,11 @@ keywords: file, filesystem, filehandle, handle, kdb+, lines, pipe, process, q, r
 ---
 # :fontawesome-solid-database: `read0`
 
-
-
-
-
 _Read text from a file or process handle_
 
 ```syntax
 read0 f           read0[f]
+read0 (f;o)       read0[(f;o)]
 read0 (f;o;n)     read0[(f;o;n)]
 read0 h           read0[h]
 read0 (fifo;n)    read0[(fifo;n)]
@@ -22,7 +19,7 @@ read0 (fifo;n)    read0[(fifo;n)]
 where
 
 -   `f` is a [file symbol](../basics/glossary.md#file-symbol)
--   `(f;o;n)` is a [file descriptor](../basics/glossary.md#file-descriptor)
+-   `o` is an offset as a non-negative integer/long
 -   `h` is a [system or connection handle](../basics/handles.md)
 -   `fifo` is a communication handle to a [Fifo](hopen.md#communication-handles)
 -   `n` is a non-negative integer
@@ -45,16 +42,24 @@ q)d:raze{read0(`:/tmp/data;x;100000)}each 100000*til 5
 ```
 
 
-## File descriptor
+## File symbol with offset
 
-Returns `n` chars from the file, starting from the position `o`.
+Return chars from file, starting from the position `o`.
 
 ```q
 q)`:foo 0: enlist "hello world"
-q)read0 (`:foo;6;5)
+`:foo
+q)read0 (`:foo;6)
 "world"
 ```
 
+Return `n` chars from the file, starting from the position `o`.
+
+```q
+q)`:foo 0: enlist "hello world"
+q)read0 (`:foo;6;2)
+"wo"
+```
 
 ## System or process handle
 

--- a/docs/ref/read1.md
+++ b/docs/ref/read1.md
@@ -11,6 +11,7 @@ _Read bytes from a file or named pipe_
 
 ```syntax
 read1 f           read1[f]
+read1 (f;o)       read1[(f;o)]
 read1 (f;o;n)     read1[(f;o;n)]
 read1 h           read1[h]
 read1 (fifo;n)    read1[(fifo;n)]
@@ -20,21 +21,19 @@ Where
 
 -   `f` is a [file symbol](../basics/glossary.md#file-symbol)
 -   `o` is an offset as a non-negative integer/long
--   `(f;o;n)` is a [file descriptor](../basics/glossary.md#file-descriptor)
 -   `h` is a [system or process handle](../basics/handles.md)
 -   `fifo` is a communication handle to a [Fifo](hopen.md#communication-handles)
 -   `n` is a length as a non-negative integer/long
 
 returns bytes from the source, as follows.
 
-
 ## File
 
 Where the argument is 
 
--   a file symbol, returns the entire content of the file
--   a file descriptor `(f;o;n)`, returns up to `n` bytes from `f` starting at `o`
--   a file descriptor `(f;o)`, returns the entire content of `f` from `o` onwards
+-   a file symbol. Returns the entire content of the file
+-   a file symbol and offset `(f;o)`. Returns the entire content of `f` from `o` onwards
+-   a file symbol, offset and length `(f;o;n)`. Returns up to `n` bytes from `f` starting at `o`
 
 ```q
 q)`:test.txt 0:("hello";"goodbye")      / write some text to a file
@@ -47,13 +46,12 @@ q)/ read 500000 lines, chunks of (up to) 100000 at a time
 q)d:raze{read1(`:/tmp/data;x;100000)}each 100000*til 5 
 ```
 
-
 ## Named pipe
 
 (Since V3.4.) Where `x` is
 
 -   a list `(fifo;length)`, returns `length` bytes read from `fifo`
--   an atom `fifo`, blocks and returns bytes from `fifo` when EOF is encountered (`0#0x` if immediate)
+-   an integer atom `fifo`, blocks and returns bytes from `fifo` when EOF is encountered (`0#0x` if immediate)
 
 ```q
 q)h:hopen`$":fifo:///etc/redhat-release"


### PR DESCRIPTION
'file descriptor' means a unique int refering to a file in linux, and its not an int here also initial uses doesnt match up with examples that follow missing example/use in read0

docs momentarily caught me out thinking a param should be an int (file descriptor) when file descriptor here meant something totally different.