### PR TITLE
incorrect use of file descriptor

### DIFF
--- a/docs/ref/file-binary.md
+++ b/docs/ref/file-binary.md
@@ -22,8 +22,8 @@ Where
 
 -   `x` is a 2-item list (a string of [types](#column-types-and-widths) and an int vector of widths) of which the order determines whether the data is parsed as little-endian or big-endian
 -   `y` is either a
-    -   [file descriptor](../basics/glossary.md#file-descriptor) to repeatedly read all available records (specified by `x`) from a file
-    -   3 element list containing [file descriptor](../basics/glossary.md#file-descriptor), offset (long) and length (long). Enables repeatedly reading all available records (specified by `x`) from a file which stops after the given byte length, starting 'offset' bytes from the start of the file.
+    -   file symbol to repeatedly read all available records (specified by `x`) from a file
+    -   3 element list containing file symbol, offset (long) and length (long). Enables repeatedly reading all available records (specified by `x`) from a file which stops after the given byte length, starting 'offset' bytes from the start of the file.
     -   string
     -   byte sequence
 

--- a/docs/ref/file-binary.md
+++ b/docs/ref/file-binary.md
@@ -23,7 +23,7 @@ Where
 -   `x` is a 2-item list (a string of [types](#column-types-and-widths) and an int vector of widths) of which the order determines whether the data is parsed as little-endian or big-endian
 -   `y` is either a
     -   file symbol to repeatedly read all available records (specified by `x`) from a file
-    - 3-element list containing the file symbol, offset (long), and length (long). Enables repeatedly reading all available records (specified by `x`) from a file, which stops after the given byte length, starting 'offset' bytes from the start of the file.
+    -   3-element list containing the file (symbol), offset (long), and length (long). Enables repeatedly reading all available records (specified by `x`) from a file, which stops after the given byte length, starting 'offset' bytes from the start of the file.
     -   string
     -   byte sequence
 

--- a/docs/ref/file-binary.md
+++ b/docs/ref/file-binary.md
@@ -23,7 +23,7 @@ Where
 -   `x` is a 2-item list (a string of [types](#column-types-and-widths) and an int vector of widths) of which the order determines whether the data is parsed as little-endian or big-endian
 -   `y` is either a
     -   file symbol to repeatedly read all available records (specified by `x`) from a file
-    -   3 element list containing file symbol, offset (long) and length (long). Enables repeatedly reading all available records (specified by `x`) from a file which stops after the given byte length, starting 'offset' bytes from the start of the file.
+    - 3-element list containing the file symbol, offset (long), and length (long). Enables repeatedly reading all available records (specified by `x`) from a file, which stops after the given byte length, starting 'offset' bytes from the start of the file.
     -   string
     -   byte sequence
 

--- a/docs/ref/file-text.md
+++ b/docs/ref/file-text.md
@@ -184,7 +184,12 @@ _Interpret a field-delimited string, list of strings, or file as a list or matri
 
 Where 
 
--   `y` is a [file descriptor](../basics/glossary.md#file-descriptor), string, or a list of strings
+-   `y` is one of the following:
+    - string
+    - list of strings
+    - file symbol
+    - 2-list (filesymbol;offset) where offset is a non-zero integer
+    - 3-list (filesymbol;offset;length) where offset and length are non-zero integers
 -   `types` is a string of [column type codes](#column-types-and-formats) in upper case
 -   `delimiter` is a char atom or 1-item list
 -   `flag` (optional, default `0`, since V3.4) is a long atom indicating whether line-returns may be embedded in strings: `0` or `1`
@@ -267,7 +272,11 @@ _Interpret a fixed-format list of strings or file as a list or matrix_
 
 Where 
 
--   `y` is a [file descriptor](../basics/glossary.md#file-descriptor) or a list of strings
+-   `y` is one of the following:
+    - list of strings
+    - file symbol
+    - 2-list (filesymbol;offset) where offset is a non-zero integer
+    - 3-list (filesymbol;offset;length) where offset and length are non-zero integers
 -   `types` is a list of [column types](#column-types-and-formats) in upper case
 -   `widths` is an int vector of field widths
 


### PR DESCRIPTION
binary used file-descriptor term instead of file system. text doc easier to see options when listed with the rest of the options.