### PR TITLE
major rewrite of bin with lots of added examples

### DIFF
--- a/docs/ref/bin.md
+++ b/docs/ref/bin.md
@@ -38,7 +38,7 @@ q)0 1 1 2 binr 0 1 2
 0 1 3
 ```
 
-`bin` uses a binary-search algorithm, which is generally more efficient on large data than the linear-search algorithm used by `?` ([Find](find.md)).
+`bin` uses a binary search algorithm, which is generally more efficient on large data than the linear-search algorithm used by `?` ([Find](find.md)).
 
 The items of `x` must be sorted ascending although `bin` does not verify this property.
 
@@ -104,7 +104,7 @@ q)t bin `a`b!(`r;2)
 
 To use `bin` with a table, the last column needs not be sorted overall, but it needs to be sorted within the equivalence classes defined by the first `n-1` columns (as shown in the previous example).
 
-`bin` can also be used with keyed tables. Here, `y` needs to contain all value columns, and it's the keys that are going to be returned (as a table).
+`bin` can also be used with keyed tables. Here, `y` needs to contain all value columns, and it is the keys that are returned (as a table).
 
 ```q
 q)kt:([k:`c`d`e`f`g`h`j`l]a:`p`p`q`q`p`p`q`q;b:0 1 0 1 0 1 0 1;c:3 3 3 3 7 7 7 7)

--- a/docs/ref/bin.md
+++ b/docs/ref/bin.md
@@ -21,9 +21,9 @@ x binr y    binr[x;y]
 Where
 
 -   `x` is a sorted list
--   `y` is an atom or list of exactly the same type (no type promotion)
+-   `y` is an atom of exactly the same type (no type promotion)
 
-returns the index of the _last_ item in `x` which is ≤`y`. The result is `-1` for `y` less than the first item of `x`. If `y` is a list, the previous is repeated for each item of `y`.
+returns the index of the _last_ item in `x` which is ≤`y`. The result is `-1` for `y` less than the first item of `x`. If `x` is a simple list, `bin` is [atomic](../basics/atomic.md) in `y`. (For higher ranks of either argument, `bin` works the same way as [`?` (Find)](find.md/#type-specific).)
 `binr` _binary search right_, introduced in V3.0 2012.07.26, gives the index of the _first_ item in `x` which is ≥`y`.
 
 ```q
@@ -81,14 +81,14 @@ r[j]=x bin y[j]    for all j in index of y
 Where
 
 -   `x` is a table of `n` columns
--   `y` is a table row with the same schema (i.e. a dictionary)
+-   `y` is a table row with the same schema (e.g. a list with `n` elements or a dictionary with the same keys as the columns of `x`)
 
 returns the index of the last row of `x` for which 
 
 - the first `n-1` values each match the first `n-1` values of `y`, and
 - the last value is not greater than the last value of `y`.
 
-If `y` is a table with the same schema as `x`, this is repeated for each row of it.
+(For higher ranks, see the examples below as well as the documentation for [`?` (Find)](find.md/#type-specific).)
 
 If no items match the criteria, either because there are no rows that match in the first `n-1` columns, or because the last value is smaller than the last value in the first such row, `0N` is returned.
 

--- a/docs/ref/bin.md
+++ b/docs/ref/bin.md
@@ -38,13 +38,13 @@ q)0 1 1 2 binr 0 1 2
 0 1 3
 ```
 
-`bin` uses a binary search algorithm, which is generally more efficient on large data than the linear-search algorithm used by `?` ([Find](find.md)).
+`bin` uses a binary search algorithm, which is generally more efficient on large data than the linear-search algorithm used by [`?` (Find)](find.md).
 
 The items of `x` must be sorted ascending although `bin` does not verify this property.
 
 !!! danger "If `x` is not sorted the result is undefined."
 
-`bin` can be also used if `x` is a dictionary with its values sorted. In this case, instead of indexes, the respective keys are returned. If a value is not found, the null value of the key type is returned.
+`bin` can be also used if `x` is a dictionary with its values sorted.
 
 ```q
 q)(`a`b`c!0 2 4) bin -1 3

--- a/docs/ref/bin.md
+++ b/docs/ref/bin.md
@@ -18,10 +18,10 @@ x binr y    binr[x;y]
 
 Where
 
--   `x` is a sorted list, or a dictionary with its values sorted 
--   `y` is a list or atom of exactly the same type (no type promotion)
+-   `x` is a sorted list
+-   `y` is an atom or list of exactly the same type (no type promotion)
 
-returns the index (in case of a list) or key (in case of a dictionary) of the _last_ item in `x` which is ≤`y`. The result is `-1` for `y` less than the first item of `x`.
+returns the index of the _last_ item in `x` which is ≤`y`. The result is `-1` for `y` less than the first item of `x`. If `y` is a list, the previous is repeated for each item of `y`.
 `binr` _binary search right_, introduced in V3.0 2012.07.26, gives the index of the _first_ item in `x` which is ≥`y`.
 
 ```q
@@ -29,6 +29,11 @@ q)0 2 4 6 8 10 bin 5
 2
 q)0 2 4 6 8 10 bin -10 0 4 5 6 20
 -1 0 2 2 3 5
+
+q)0 1 1 2 bin 0 1 2
+0 2 3
+q)0 1 1 2 binr 0 1 2
+0 1 3
 ```
 
 `bin` uses a binary-search algorithm, which is generally more efficient on large data than the linear-search algorithm used by `?` ([Find](find.md)).
@@ -36,6 +41,20 @@ q)0 2 4 6 8 10 bin -10 0 4 5 6 20
 The items of `x` must be sorted ascending although `bin` does not verify this property.
 
 !!! danger "If `x` is not sorted the result is undefined."
+
+`bin` can be also used if `x` is a dictionary with its values sorted. In this case, instead of indexes, the respective keys are returned. If a value is not found, the null value of the key type is returned.
+
+```q
+q)(`a`b`c!0 2 4) bin -1 3
+``b
+```
+
+Non-simple lists can also be used. In this case, items are lexicographically sorted.
+
+```q
+q)("apple";"banana";"coffee") bin ("anise";"berry";"curry")
+-1 1 2
+```
 
 The result `r` can be interpreted as follows: for an atom `y`, `r` is an integer atom whose value is either a valid index of `x` or `-1`. In general:
 
@@ -50,8 +69,6 @@ and
 ```txt
 r[j]=x bin y[j]    for all j in index of y
 ```
-
-`bin` and `binr` are right-atomic: their results have the same count as `y`.
 
 `bin` is the function used in [`aj`](aj.md) and [`lj`](lj.md).
 

--- a/docs/ref/bin.md
+++ b/docs/ref/bin.md
@@ -16,6 +16,8 @@ x bin  y    bin[x;y]
 x binr y    binr[x;y]
 ```
 
+## Lists
+
 Where
 
 -   `x` is a sorted list
@@ -73,6 +75,60 @@ r[j]=x bin y[j]    for all j in index of y
 `bin` is the function used in [`aj`](aj.md) and [`lj`](lj.md).
 
 `bin` and `binr` are [multithreaded primitives](../kb/mt-primitives.md).
+
+## Tables
+
+Where
+
+-   `x` is a table of `n` columns
+-   `y` is a table row with the same schema (i.e. a dictionary)
+
+returns the index of the last row of `x` for which 
+
+- the first `n-1` values each match the first `n-1` values of `y`, and
+- the last value is not greater than the last value of `y`.
+
+If `y` is a table with the same schema as `x`, this is repeated for each row of it.
+
+If no items match the criteria, either because there are no rows that match in the first `n-1` columns, or because the last value is smaller than the last value in the first such row, `0N` is returned.
+
+```q
+q)t:([]a:`p`p`p`q`q`q;b:0 2 4 0 2 4)
+q)t bin `a`b!(`p;3)
+1
+q)t bin ([]a:`q;b:-1 1 3 5)
+0N 3 4 5
+q)t bin `a`b!(`r;2)
+0N
+```
+
+To use `bin` with a table, the last column needs not be sorted overall, but it needs to be sorted within the equivalence classes defined by the first `n-1` columns (as shown in the previous example).
+
+`bin` can also be used with keyed tables. Here, `y` needs to contain all value columns, and it's the keys that are going to be returned (as a table).
+
+```q
+q)kt:([k:`c`d`e`f`g`h`j`l]a:`p`p`q`q`p`p`q`q;b:0 1 0 1 0 1 0 1;c:3 3 3 3 7 7 7 7)
+q)kt
+k| a b c
+-| -----
+c| p 0 3
+d| p 1 3
+e| q 0 3
+f| q 1 3
+g| p 0 7
+h| p 1 7
+j| q 0 7
+l| q 1 7
+q)kt bin ([]a:`p`q`q`r;b:1;c:4 8 2 4)
+k
+-
+d
+l
+
+
+q)(kt bin ([]a:`p`q`q`r;b:1;c:4 8 2 4))`k
+`d`l``
+```
 
 ## Sorted third column
 

--- a/docs/ref/bin.md
+++ b/docs/ref/bin.md
@@ -18,15 +18,22 @@ x binr y    binr[x;y]
 
 Where
 
--   `x` is a sorted list
+-   `x` is a sorted list, or a dictionary with its values sorted 
 -   `y` is a list or atom of exactly the same type (no type promotion)
 
-returns the index of the _last_ item in `x` which is ≤`y`. The result is `-1` for `y` less than the first item of `x`.
+returns the index (in case of a list) or key (in case of a dictionary) of the _last_ item in `x` which is ≤`y`. The result is `-1` for `y` less than the first item of `x`.
 `binr` _binary search right_, introduced in V3.0 2012.07.26, gives the index of the _first_ item in `x` which is ≥`y`.
 
-They use a binary-search algorithm, which is generally more efficient on large data than the linear-search algorithm used by `?` ([Find](find.md)).
+```q
+q)0 2 4 6 8 10 bin 5
+2
+q)0 2 4 6 8 10 bin -10 0 4 5 6 20
+-1 0 2 2 3 5
+```
 
-The items of `x` should be sorted ascending although `bin` does not verify this property.
+`bin` uses a binary-search algorithm, which is generally more efficient on large data than the linear-search algorithm used by `?` ([Find](find.md)).
+
+The items of `x` must be sorted ascending although `bin` does not verify this property.
 
 !!! danger "If `x` is not sorted the result is undefined."
 
@@ -44,30 +51,11 @@ and
 r[j]=x bin y[j]    for all j in index of y
 ```
 
-Essentially `bin` gives a half-open interval on the left.
-
 `bin` and `binr` are right-atomic: their results have the same count as `y`.
 
-`bin` also operates on tuples and table columns and is the function used in [`aj`](aj.md) and [`lj`](lj.md).
+`bin` is the function used in [`aj`](aj.md) and [`lj`](lj.md).
 
 `bin` and `binr` are [multithreaded primitives](../kb/mt-primitives.md).
-
-```q
-q)0 2 4 6 8 10 bin 5
-2
-q)0 2 4 6 8 10 bin -10 0 4 5 6 20
--1 0 2 2 3 5
-```
-
-If the left argument items are not distinct the result is not the same as would be obtained with `?`:
-
-```q
-q)1 2 3 3 4 bin 2 3
-1 3
-q)1 2 3 3 4 ? 2 3
-1 2
-```
-
 
 ## Sorted third column
 


### PR DESCRIPTION
Added the general description for the usage with tables as well as lots of examples.
Deleted obsolete or incorrect content. (`bin` not returning the same thing as `?` no longer matters as `binr` will do that; `bin` is not right-atomic, only if the left argument is of rank 1.)

Fixes #352  