### PR TITLE
Strip q) and >>> Prompts from Copied Code Blocks

### DIFF
--- a/docs/scripts/strip-repl-prompts.js
+++ b/docs/scripts/strip-repl-prompts.js
@@ -1,0 +1,130 @@
+// When a user clicks a code copy button, copy the code but remove
+// leading REPL prompts (q), >>>, Python continuation (...), and In [n]:.
+//
+// Save this file as: docs/scripts/strip-repl-prompts.js
+//
+// In mkdocs.yml, add under extra_javascript:
+//   - scripts/strip-repl-prompts.js
+//
+// Ensure it loads after any other custom scripts.
+
+(function () {
+  'use strict';
+
+  // Selectors covering Material for MkDocs copy button variations
+  const COPY_BUTTON_SELECTORS = [
+    '.md-code .md-clipboard',
+    'button.md-code__copy',
+    'button.md-clipboard',
+    '.md-code__copy-button',
+    '.md-clipboard__button'
+  ].join(',');
+
+  // Match leading REPL prompts at start of line:
+  //   q)
+  //   >>>
+  //   ...
+  //   In [n]:
+  const REPL_PROMPT_RE = /^\s*(?:q\)|>>>|\.\.\.|In\s*\[\d+\]:)\s?/;
+
+  function closest(el, selector) {
+    while (el) {
+      if (el.matches && el.matches(selector)) return el;
+      el = el.parentElement;
+    }
+    return null;
+  }
+
+  function stripReplPrompts(text) {
+    if (!text) return text;
+    return text
+      .split('\n')
+      .map(line => line.replace(REPL_PROMPT_RE, ''))
+      .join('\n');
+  }
+
+  function getCodeTextFromBlock(container) {
+    if (!container) return '';
+    const codeElem =
+      container.querySelector('pre > code') ||
+      container.querySelector('code');
+    if (!codeElem) return '';
+    return codeElem.textContent || '';
+  }
+
+  function writeToClipboard(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(text);
+    }
+
+    return new Promise((resolve, reject) => {
+      try {
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.left = '-9999px';
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        const ok = document.execCommand('copy');
+        document.body.removeChild(ta);
+        if (ok) resolve();
+        else reject(new Error('execCommand copy failed'));
+      } catch (err) {
+        reject(err);
+      }
+    });
+  }
+
+  function wireCopyButtons() {
+    document.querySelectorAll(COPY_BUTTON_SELECTORS).forEach(btn => {
+      if (btn.__replPromptBound) return;
+      btn.__replPromptBound = true;
+
+      btn.addEventListener('click', function (ev) {
+        try {
+          const codeContainer =
+            closest(btn, '.md-code') ||
+            closest(btn, 'pre') ||
+            closest(btn, 'code') ||
+            btn.parentElement;
+
+          const raw = getCodeTextFromBlock(codeContainer);
+          if (!raw) return;
+
+          const cleaned = stripReplPrompts(raw);
+          if (cleaned === raw) return;
+
+          ev.preventDefault();
+          ev.stopPropagation();
+
+          writeToClipboard(cleaned).then(() => {
+            btn.dispatchEvent(
+              new CustomEvent('repl-copy-success', { bubbles: true })
+            );
+          }).catch(() => {
+            // allow fallback behavior
+          });
+
+        } catch (err) {
+          return;
+        }
+
+      }, { capture: true });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    wireCopyButtons();
+
+    const observer = new MutationObserver(() => {
+      wireCopyButtons();
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true
+    });
+  });
+
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ extra_javascript:
   - https://code.kx.com/scripts/polyfill.min.js
   - https://code.kx.com/scripts/tex-mml-chtml.js
   - scripts/qsearch.js # site-specific search engine
+  - scripts/strip-repl-prompts.js # Removes q), >>>, and ... prompts from copied code blocks (keeps prompts visible in docs)
 
 markdown_extensions:
   - abbr


### PR DESCRIPTION
**Summary**

Exclude REPL prompts (q), >>>, and ...) from code copied using the Material for MkDocs copy-to-clipboard button on https://code.kx.com/q/.

Prompts remain visible in rendered documentation but are removed from clipboard output to prevent invalid input when pasting into q or Python interpreters.

**What this MR does:**
- Strips leading q) from q examples on copy.
- Strips leading >>> and ... from Python REPL examples on copy.
- Does not modify rendered code blocks.
- Does not affect syntax highlighting.

**Scope**
Applies to the KxSystems/docs repository and affects copy behavior only.

**Testing**
- Verified that copying q examples no longer includes q).
- Verified that copying Python REPL examples no longer includes >>> or ....
- Confirmed no regressions in rendering or highlighting.
- Recommended page for testing: [Q versions of Python basic programming examples](https://code.kx.com/q/learn/python/examples/).