### PR TITLE
DOCN-151: Rename PyKX to KDB-X Python

### DIFF
--- a/docs/interfaces/python.md
+++ b/docs/interfaces/python.md
@@ -6,13 +6,11 @@ keywords: python, pykx, embedpy, api, ipc
 
 # Python client for kdb+
 
-The PyKX interface exposes q as a domain-specific language (DSL) embedded within Python, and also permits IPC connectivity to kdb+ from Python applications.
+**[KDB-X Python](https://code.kx.com/pykx/getting-started/installing.html)** (`pykx>=4.0`) is the Python interface for **[KDB-X](https://developer.kx.com/products/kdb-x/install)**, the evolution of kdb+. It exposes q as a domain-specific language (DSL) embedded within Python, and permits IPC connectivity from Python applications. It supports:
 
-PyKX supports three principal use cases:
+1. Storing, querying, manipulating and using q objects within a Python process.
+2. Querying external KDB-X processes via an IPC interface.
+3. Embedding Python functionality within a native q session via the under q functionality.
 
-1. It allows users to store, query, manipulate and use q objects within a Python process.
-2. It allows users to query external q processes via an IPC interface.
-3. It allows users to embed Python functionality within a native q session using it's under q functionality.
-
-It is documented and available to download from [https://code.kx.com/pykx](https://code.kx.com/pykx).
+The previous [PyKX](https://code.kx.com/pykx/3.2/getting-started/installing.html) (`pykx<4.0`) is powered by kdb+. If you're migrating from PyKX to KDB-X Python, refer to the [migration guide](https://code.kx.com/pykx/upgrades/3040.html).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -610,6 +610,6 @@ nav:
   - kdb Insights SDK: 'https://code.kx.com/insights'
   - kdb Insights Enterprise: 'https://code.kx.com/insights/enterprise'
   - KDB.AI: 'https://code.kx.com/kdbai'
-  - PyKX: 'https://code.kx.com/pykx'
+  - KDB-X Python: 'https://code.kx.com/pykx'
   - APIs: 'https://code.kx.com/insights/api'
   - Help: 'https://code.kx.com/home/support.html'


### PR DESCRIPTION
## Summary
Updates the Python interface documentation for the PyKX → KDB-X Python rename (`pykx>=4.0`).

- Rewrites `docs/interfaces/python.md` to introduce **KDB-X Python** as the Python interface for KDB-X (the evolution of kdb+), with a pointer to the migration guide for users on `pykx<4.0`.
- Renames the `PyKX` navigation entry to `KDB-X Python` in `mkdocs.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)